### PR TITLE
fix: prevent speech recognition crash in dev mode

### DIFF
--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Allow microphone access for speech-to-text -->
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,7 +40,7 @@
       "icons/icon.ico"
     ],
     "macOS": {
-      "entitlements": null,
+      "entitlements": "Entitlements.plist",
       "exceptionDomain": "",
       "frameworks": [],
       "providerShortName": null,


### PR DESCRIPTION
## Summary

- Add `Entitlements.plist` with audio input permission for production builds
- Configure `tauri.conf.json` to use entitlements for macOS bundle  
- Add dev mode detection to disable speech recognition when `Info.plist` is not bundled
- Request microphone permission via `getUserMedia` before starting speech recognition

## Root Cause

macOS terminates apps via TCC (Transparency, Consent, and Control) when accessing speech recognition without `NSSpeechRecognitionUsageDescription` in `Info.plist`. This plist is only bundled in production builds, not dev mode.

## Changes

| File | Change |
|------|--------|
| `src-tauri/Entitlements.plist` | New file with `com.apple.security.device.audio-input` |
| `src-tauri/tauri.conf.json` | Reference entitlements file |
| `src/hooks/useSpeechToText.ts` | Dev mode detection + graceful permission handling |

## Test Plan

- [ ] Run `npm run tauri dev` — mic button should be hidden, no crash
- [ ] Run `npm run tauri build` then open the `.app` — mic should work
- [ ] Check console for `[Speech] Speech recognition disabled in dev mode` in dev