### PR TITLE
feat: Voice Isolation prompt for noisy environments

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,9 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             audio_session::activate_voice_session,
             audio_session::deactivate_voice_session,
+            audio_session::get_mic_mode,
+            audio_session::show_mic_mode_picker,
+            audio_session::is_voice_isolation_supported,
         ])
         .setup(|app| {
             if cfg!(debug_assertions) {

--- a/src/components/MicModeIndicator.tsx
+++ b/src/components/MicModeIndicator.tsx
@@ -1,0 +1,74 @@
+import { useState, useEffect } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+
+type MicMode = 'standard' | 'voiceIsolation' | 'wideSpectrum' | 'unknown'
+
+const MODE_LABELS: Record<MicMode, string> = {
+  standard: 'Standard',
+  voiceIsolation: 'Voice Isolation',
+  wideSpectrum: 'Wide Spectrum',
+  unknown: 'Unknown',
+}
+
+const MODE_COLORS: Record<MicMode, string> = {
+  standard: 'var(--text-tertiary)',
+  voiceIsolation: 'var(--success)',
+  wideSpectrum: 'var(--warning)',
+  unknown: 'var(--text-tertiary)',
+}
+
+interface MicModeIndicatorProps {
+  isListening: boolean
+}
+
+export function MicModeIndicator({ isListening }: MicModeIndicatorProps) {
+  const [micMode, setMicMode] = useState<MicMode>('unknown')
+  const [isSupported, setIsSupported] = useState(false)
+
+  // Check mic mode when listening starts/stops
+  useEffect(() => {
+    async function checkMicMode() {
+      try {
+        const supported = await invoke<boolean>('is_voice_isolation_supported')
+        setIsSupported(supported)
+
+        if (supported) {
+          const mode = await invoke<string>('get_mic_mode')
+          setMicMode(mode as MicMode)
+        }
+      } catch (e) {
+        console.warn('Failed to check mic mode:', e)
+      }
+    }
+
+    checkMicMode()
+
+    // Poll while listening to catch mode changes
+    if (isListening) {
+      const interval = setInterval(checkMicMode, 2000)
+      return () => clearInterval(interval)
+    }
+  }, [isListening])
+
+  if (!isSupported) return null
+
+  const isVoiceIsolation = micMode === 'voiceIsolation'
+
+  return (
+    <div
+      className="mic-mode-indicator"
+      style={{ '--mode-color': MODE_COLORS[micMode] } as React.CSSProperties}
+      title={`Mic Mode: ${MODE_LABELS[micMode]}`}
+    >
+      <div className={`mic-mode-dot ${isVoiceIsolation ? 'active' : ''}`} />
+      <span className="mic-mode-label">
+        {isVoiceIsolation ? 'Voice Isolation' : 'Standard'}
+      </span>
+      {isVoiceIsolation && (
+        <svg className="mic-mode-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      )}
+    </div>
+  )
+}

--- a/src/components/TranslationView.tsx
+++ b/src/components/TranslationView.tsx
@@ -11,6 +11,7 @@ import { MicButton } from './MicButton'
 import { SpeechPreview } from './SpeechPreview'
 import { ClearInputButton } from './ClearInputButton'
 import { SpeedSelector } from './SpeedSelector'
+import { VoiceIsolationPrompt } from './VoiceIsolationPrompt'
 
 const SPEECH_LANGS = [
   { code: 'en', label: 'EN' },
@@ -28,9 +29,10 @@ export function TranslationView() {
     sourceLang, setSourceLang,
     targetLang, setTargetLang
   } = useAppStore()
-  const { speechLang, setSpeechLang, ttsRate, setTtsRate } = useSettingsStore()
+  const { speechLang, setSpeechLang, ttsRate, setTtsRate, voiceIsolationPromptDismissed } = useSettingsStore()
   const { translate } = useTranslation()
   const [copied, setCopied] = useState(false)
+  const [showVoiceIsolationPrompt, setShowVoiceIsolationPrompt] = useState(false)
 
   // Text-to-speech for output
   const { isSpeaking, isSupported: isTTSSupported, speak, stop } = useTextToSpeech({ rate: ttsRate })
@@ -67,6 +69,13 @@ export function TranslationView() {
     lang: speechLang,
     onTextReady: handleTextReady,
   })
+
+  // Show Voice Isolation prompt when user starts listening for the first time
+  useEffect(() => {
+    if (isListening && !voiceIsolationPromptDismissed) {
+      setShowVoiceIsolationPrompt(true)
+    }
+  }, [isListening, voiceIsolationPromptDismissed])
 
   const handleCopy = async () => {
     if (!outputText) return
@@ -155,6 +164,10 @@ export function TranslationView() {
                   isVisible={isListening}
                   transcript={transcript}
                   interimTranscript={interimTranscript}
+                />
+                <VoiceIsolationPrompt
+                  isVisible={showVoiceIsolationPrompt}
+                  onDismiss={() => setShowVoiceIsolationPrompt(false)}
                 />
               </div>
             </div>

--- a/src/components/TranslationView.tsx
+++ b/src/components/TranslationView.tsx
@@ -12,6 +12,7 @@ import { SpeechPreview } from './SpeechPreview'
 import { ClearInputButton } from './ClearInputButton'
 import { SpeedSelector } from './SpeedSelector'
 import { VoiceIsolationPrompt } from './VoiceIsolationPrompt'
+import { MicModeIndicator } from './MicModeIndicator'
 
 const SPEECH_LANGS = [
   { code: 'en', label: 'EN' },
@@ -136,8 +137,8 @@ export function TranslationView() {
             "
           />
           <div className="px-3 py-1.5 border-t border-[var(--border-color)] flex items-center justify-between">
-            {/* Left: Mic button with language selector */}
-            <div className="flex items-center">
+            {/* Left: Mic button with language selector and mode indicator */}
+            <div className="flex items-center gap-2">
               <div className="relative">
                 <div className="button-group">
                   <MicButton
@@ -170,6 +171,7 @@ export function TranslationView() {
                   onDismiss={() => setShowVoiceIsolationPrompt(false)}
                 />
               </div>
+              <MicModeIndicator isListening={isListening} />
             </div>
             {/* Right: Char count */}
             <span className="text-[10px] text-[var(--text-tertiary)]">

--- a/src/components/VoiceIsolationPrompt.tsx
+++ b/src/components/VoiceIsolationPrompt.tsx
@@ -1,0 +1,82 @@
+import { useState, useEffect } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import { useSettingsStore } from '../stores/settingsStore'
+
+interface VoiceIsolationPromptProps {
+  isVisible: boolean
+  onDismiss: () => void
+}
+
+export function VoiceIsolationPrompt({ isVisible, onDismiss }: VoiceIsolationPromptProps) {
+  const [micMode, setMicMode] = useState<string>('unknown')
+  const [isSupported, setIsSupported] = useState(false)
+  const { voiceIsolationPromptDismissed, setVoiceIsolationPromptDismissed } = useSettingsStore()
+
+  // Check Voice Isolation support and current mode
+  useEffect(() => {
+    async function checkVoiceIsolation() {
+      try {
+        const supported = await invoke<boolean>('is_voice_isolation_supported')
+        setIsSupported(supported)
+
+        if (supported) {
+          const mode = await invoke<string>('get_mic_mode')
+          setMicMode(mode)
+        }
+      } catch (e) {
+        console.warn('Failed to check voice isolation:', e)
+      }
+    }
+
+    if (isVisible) {
+      checkVoiceIsolation()
+    }
+  }, [isVisible])
+
+  // Don't show if already dismissed, not supported, or already enabled
+  if (!isVisible || voiceIsolationPromptDismissed || !isSupported || micMode === 'voiceIsolation') {
+    return null
+  }
+
+  const handleEnable = async () => {
+    try {
+      await invoke('show_mic_mode_picker')
+    } catch (e) {
+      console.warn('Failed to show mic mode picker:', e)
+    }
+    setVoiceIsolationPromptDismissed(true)
+    onDismiss()
+  }
+
+  const handleDismiss = () => {
+    setVoiceIsolationPromptDismissed(true)
+    onDismiss()
+  }
+
+  return (
+    <div className="voice-isolation-prompt">
+      <div className="voice-isolation-prompt-content">
+        <div className="voice-isolation-prompt-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+            <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+            <line x1="12" y1="19" x2="12" y2="22" />
+            <circle cx="12" cy="12" r="10" strokeDasharray="4 4" opacity="0.5" />
+          </svg>
+        </div>
+        <div className="voice-isolation-prompt-text">
+          <strong>Noisy environment?</strong>
+          <span>Enable Voice Isolation for clearer speech recognition</span>
+        </div>
+      </div>
+      <div className="voice-isolation-prompt-actions">
+        <button onClick={handleDismiss} className="voice-isolation-btn-dismiss">
+          Dismiss
+        </button>
+        <button onClick={handleEnable} className="voice-isolation-btn-enable">
+          Enable
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1351,3 +1351,144 @@ html.no-transition * {
   color: var(--text-tertiary);
   text-align: center;
 }
+
+/* ============================================
+   Voice Isolation Prompt
+   ============================================ */
+.voice-isolation-prompt {
+  position: absolute;
+  bottom: calc(100% + 12px);
+  left: 0;
+  min-width: 280px;
+  max-width: 320px;
+  padding: 14px 16px;
+
+  /* Liquid Glass - elevated style */
+  background: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--glass-shadow-elevated), var(--glass-highlight-edge);
+
+  /* Animation */
+  animation: voice-isolation-appear 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+  z-index: 100;
+}
+
+@keyframes voice-isolation-appear {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* Pointer/Arrow */
+.voice-isolation-prompt::after {
+  content: '';
+  position: absolute;
+  bottom: -6px;
+  left: 20px;
+  width: 12px;
+  height: 12px;
+  background: var(--glass-bg);
+  border-right: 1px solid var(--glass-border);
+  border-bottom: 1px solid var(--glass-border);
+  transform: rotate(45deg);
+  backdrop-filter: blur(var(--glass-blur));
+}
+
+.voice-isolation-prompt-content {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.voice-isolation-prompt-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: linear-gradient(135deg, var(--accent-blue), var(--accent-purple));
+  border-radius: 10px;
+  color: white;
+}
+
+.voice-isolation-prompt-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.voice-isolation-prompt-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+
+.voice-isolation-prompt-text strong {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+}
+
+.voice-isolation-prompt-text span {
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.voice-isolation-prompt-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.voice-isolation-btn-dismiss {
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.voice-isolation-btn-dismiss:hover {
+  background: var(--hover-overlay);
+  border-color: var(--text-tertiary);
+  color: var(--text-primary);
+}
+
+.voice-isolation-btn-enable {
+  padding: 6px 14px;
+  font-size: 12px;
+  font-weight: 600;
+  color: white;
+  background: var(--accent-blue);
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  box-shadow: 0 2px 6px rgba(49, 57, 251, 0.25);
+}
+
+.voice-isolation-btn-enable:hover {
+  background: var(--accent-purple);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 10px rgba(49, 57, 251, 0.35);
+}
+
+.voice-isolation-btn-enable:active {
+  transform: translateY(0);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1492,3 +1492,46 @@ html.no-transition * {
 .voice-isolation-btn-enable:active {
   transform: translateY(0);
 }
+
+/* ============================================
+   Mic Mode Indicator
+   ============================================ */
+.mic-mode-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px 4px 8px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--mode-color, var(--text-tertiary));
+  transition: all var(--transition-fast);
+}
+
+.mic-mode-indicator:hover {
+  border-color: var(--text-tertiary);
+}
+
+.mic-mode-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--mode-color, var(--text-tertiary));
+  transition: all var(--transition-fast);
+}
+
+.mic-mode-dot.active {
+  box-shadow: 0 0 6px var(--success);
+}
+
+.mic-mode-label {
+  letter-spacing: 0.01em;
+}
+
+.mic-mode-check {
+  width: 12px;
+  height: 12px;
+  color: var(--success);
+}

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -34,6 +34,10 @@ interface SettingsState {
   ttsRate: number; // Text-to-speech rate (0.5 to 2.0)
   setTtsRate: (rate: number) => void;
 
+  // Voice Isolation
+  voiceIsolationPromptDismissed: boolean; // User dismissed the Voice Isolation prompt
+  setVoiceIsolationPromptDismissed: (dismissed: boolean) => void;
+
   // Setup
   isSetupComplete: boolean;
   setSetupComplete: (complete: boolean) => void;
@@ -75,6 +79,10 @@ export const useSettingsStore = create<SettingsState>()(
       setSpeechLang: (lang) => set({ speechLang: lang }),
       ttsRate: 1.0, // Default TTS rate
       setTtsRate: (rate) => set({ ttsRate: Math.round(rate * 100) / 100 }),
+
+      // Voice Isolation
+      voiceIsolationPromptDismissed: false,
+      setVoiceIsolationPromptDismissed: (dismissed) => set({ voiceIsolationPromptDismissed: dismissed }),
 
       // Setup
       isSetupComplete: false,


### PR DESCRIPTION
## Summary
- Prompt users to enable macOS Voice Isolation when using mic in noisy environments
- Uses Apple's Neural Engine ML for speaker isolation (same as FaceTime)
- One-time prompt, remembers user choice

## Changes
- `src-tauri/src/audio_session.rs`: Add commands for mic mode detection and picker
- `src/components/VoiceIsolationPrompt.tsx`: Glass UI prompt component
- `src/stores/settingsStore.ts`: Add dismissed preference
- `src/components/TranslationView.tsx`: Integrate prompt on first mic use
- `src/index.css`: Liquid glass styling for prompt

## UX Flow
1. User clicks mic button
2. Prompt appears: "Noisy environment? Enable Voice Isolation"
3. User clicks Enable → System mic mode picker opens
4. User selects Voice Isolation → Done (won't ask again)

## Screenshots
*Pending UX review*

## Test plan
- [ ] Build app and click mic button
- [ ] Verify prompt appears on first mic use
- [ ] Click Enable → system picker opens
- [ ] Dismiss → prompt hidden, won't show again
- [ ] Check dark/light mode styling