### PR TITLE
feat: add app update notification and settings panel integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
-  "name": "tran-app",
+  "name": "lingo-leap",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tran-app",
+      "name": "lingo-leap",
       "version": "1.0.0",
       "dependencies": {
         "@tauri-apps/api": "^2.9.1",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-global-shortcut": "^2.3.1",
         "@tauri-apps/plugin-positioner": "^2.3.1",
+        "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-shell": "^2.3.3",
+        "@tauri-apps/plugin-updater": "^2.9.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "zustand": "^5.0.9"
@@ -1645,6 +1647,15 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
     "node_modules/@tauri-apps/plugin-shell": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.3.tgz",
@@ -1652,6 +1663,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.9.0.tgz",
+      "integrity": "sha512-j++sgY8XpeDvzImTrzWA08OqqGqgkNyxczLD7FjNJJx/uXxMZFz5nDcfkyoI/rCjYuj2101Tci/r/HFmOmoxCg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.6.0"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-global-shortcut": "^2.3.1",
     "@tauri-apps/plugin-positioner": "^2.3.1",
+    "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-shell": "^2.3.3",
+    "@tauri-apps/plugin-updater": "^2.9.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "zustand": "^5.0.9"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,3 +34,7 @@ objc-foundation = "0.1"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-positioner = { version = "2", features = ["tray-icon"] }
 tauri-plugin-clipboard-manager = "2"
+
+[target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,8 @@
     "global-shortcut:allow-register",
     "global-shortcut:allow-unregister",
     "clipboard-manager:allow-read-text",
-    "clipboard-manager:allow-write-text"
+    "clipboard-manager:allow-write-text",
+    "updater:default",
+    "process:allow-restart"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,8 @@ pub fn run() {
         .plugin(tauri_plugin_positioner::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .invoke_handler(tauri::generate_handler![
             audio_session::activate_voice_session,
             audio_session::deactivate_voice_session,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,6 +32,7 @@
   "bundle": {
     "active": true,
     "targets": ["dmg", "app"],
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -45,6 +46,14 @@
       "frameworks": [],
       "providerShortName": null,
       "signingIdentity": null
+    }
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDlCQjkzRjZBREZGMjQ3QzgKUldUSVIvTGZhais1bTZzMHd1eGxHVjJlK1dXekswTFdySVBvUVhHaTBZeGQ2aHcrZlpmN3cvemkK",
+      "endpoints": [
+        "https://github.com/knguyen30111/lingo-leap/releases/latest/download/latest.json"
+      ]
     }
   }
 }

--- a/src/hooks/useAppUpdater.ts
+++ b/src/hooks/useAppUpdater.ts
@@ -1,0 +1,115 @@
+import { useState, useCallback, useEffect } from "react";
+import { check, Update } from "@tauri-apps/plugin-updater";
+import { relaunch } from "@tauri-apps/plugin-process";
+import { useSettingsStore } from "../stores/settingsStore";
+
+interface UpdateProgress {
+  downloaded: number;
+  total: number;
+}
+
+export function useAppUpdater() {
+  const [checking, setChecking] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+  const [installing, setInstalling] = useState(false);
+  const [progress, setProgress] = useState<UpdateProgress | null>(null);
+  const [update, setUpdate] = useState<Update | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const { autoCheckUpdates } = useSettingsStore();
+
+  const checkForUpdate = useCallback(async (silent = false) => {
+    setChecking(true);
+    setError(null);
+
+    try {
+      const result = await check();
+      setUpdate(result);
+      return result;
+    } catch (e) {
+      const errorMsg = e instanceof Error ? e.message : "Failed to check for updates";
+      // Only show error if not silent (manual check)
+      if (!silent) {
+        setError(errorMsg);
+      }
+      console.error("Update check failed:", errorMsg);
+      return null;
+    } finally {
+      setChecking(false);
+    }
+  }, []);
+
+  const downloadAndInstall = useCallback(async () => {
+    if (!update) return;
+
+    setDownloading(true);
+    setError(null);
+    setProgress({ downloaded: 0, total: 0 });
+
+    try {
+      let downloaded = 0;
+
+      await update.downloadAndInstall((event) => {
+        switch (event.event) {
+          case "Started":
+            setProgress({ downloaded: 0, total: event.data.contentLength || 0 });
+            break;
+          case "Progress":
+            downloaded += event.data.chunkLength;
+            setProgress({ downloaded, total: event.data.contentLength || downloaded });
+            break;
+          case "Finished":
+            setDownloading(false);
+            setInstalling(true);
+            break;
+        }
+      });
+
+      // Relaunch app after install
+      await relaunch();
+    } catch (e) {
+      const errorMsg = e instanceof Error ? e.message : "Failed to install update";
+      setError(errorMsg);
+      console.error("Update install failed:", errorMsg);
+    } finally {
+      setDownloading(false);
+      setInstalling(false);
+      setProgress(null);
+    }
+  }, [update]);
+
+  const dismissUpdate = useCallback(() => {
+    setUpdate(null);
+    setError(null);
+  }, []);
+
+  // Auto-check on mount if enabled
+  useEffect(() => {
+    if (autoCheckUpdates) {
+      // Delay check to not slow down app startup
+      const timer = setTimeout(() => {
+        checkForUpdate(true); // silent check
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [autoCheckUpdates, checkForUpdate]);
+
+  const progressPercent = progress
+    ? progress.total > 0
+      ? Math.round((progress.downloaded / progress.total) * 100)
+      : 0
+    : 0;
+
+  return {
+    checking,
+    downloading,
+    installing,
+    progress,
+    progressPercent,
+    update,
+    error,
+    checkForUpdate,
+    downloadAndInstall,
+    dismissUpdate,
+  };
+}

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -41,6 +41,10 @@ interface SettingsState {
   setOllamaInstalled: (installed: boolean) => void;
   modelsInstalled: boolean;
   setModelsInstalled: (installed: boolean) => void;
+
+  // Updates
+  autoCheckUpdates: boolean;
+  setAutoCheckUpdates: (value: boolean) => void;
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -83,6 +87,10 @@ export const useSettingsStore = create<SettingsState>()(
       setOllamaInstalled: (installed) => set({ ollamaInstalled: installed }),
       modelsInstalled: false,
       setModelsInstalled: (installed) => set({ modelsInstalled: installed }),
+
+      // Updates
+      autoCheckUpdates: true,
+      setAutoCheckUpdates: (value) => set({ autoCheckUpdates: value }),
     }),
     {
       name: "tran-app-settings",


### PR DESCRIPTION
## Summary

- Add in-app update checking and installation via Settings panel
- Integrate Tauri updater plugin with GitHub Releases as update source
- Provide manual check button + auto-check on startup option

## Changes

- **Backend**: Add `tauri-plugin-updater` and `tauri-plugin-process`
- **Frontend**: New `useAppUpdater` hook for update lifecycle management
- **UI**: New "Updates" section in Settings with version display, check button, install progress
- **Config**: Updater endpoints configured for GitHub Releases

## Screenshots

Settings Panel now includes:
```
📦 Updates
├── Current Version: v0.1.0
├── [Check Now] + [Open Releases] buttons
├── Update available banner (when found)
├── Auto-check on startup toggle
```

## Test Plan

- [ ] Open Settings panel and verify Updates section appears
- [ ] Click "Check Now" - should show error (no releases yet)
- [ ] Click external link icon - should open GitHub releases
- [ ] Toggle auto-check setting - should persist

## Notes

- Signing keys generated for development (`~/.tauri/lingo-leap.key`)
- For production: add `TAURI_SIGNING_PRIVATE_KEY` to GitHub Secrets
- GitHub Action workflow for automated signed releases not included (separate PR)