### PR TITLE
feat: enhance audio settings and prevent audio ducking

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useSettingsStore, ThemeMode } from "../stores/settingsStore";
 import { useOllama } from "../hooks/useOllama";
 import { useAudioDevices } from "../hooks/useAudioDevices";
+import { useAudioOutputDevices } from "../hooks/useAudioOutputDevices";
 
 interface SettingsPanelProps {
   onClose: () => void;
@@ -81,8 +82,17 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
     devices,
     selectedDeviceId,
     selectDevice,
+    refreshDevices,
     isLoading: isLoadingDevices,
   } = useAudioDevices();
+  const {
+    devices: outputDevices,
+    selectedDeviceId: selectedOutputDeviceId,
+    selectDevice: selectOutputDevice,
+    testSound,
+    isTesting,
+    isLoading: isLoadingOutputDevices,
+  } = useAudioOutputDevices();
 
   const handleSaveHost = () => {
     setOllamaHost(localHost);
@@ -331,19 +341,20 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
             </SettingRow>
           </SettingsSection>
 
-          {/* Input Section */}
+          {/* Audio Section */}
           <SettingsSection
             icon={
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
               </svg>
             }
-            title="Input"
+            title="Audio"
           >
             <SettingRow label="Microphone" description="Voice input device">
               <select
                 value={selectedDeviceId || ""}
                 onChange={(e) => selectDevice(e.target.value)}
+                onFocus={() => refreshDevices(true)}
                 disabled={isLoadingDevices || devices.length === 0}
                 className="select-glass w-full text-sm"
               >
@@ -358,6 +369,47 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
                   ))
                 )}
               </select>
+            </SettingRow>
+
+            <SettingRow label="Speaker" description="Audio output device">
+              <div className="flex gap-2 w-full">
+                <select
+                  value={selectedOutputDeviceId || ""}
+                  onChange={(e) => selectOutputDevice(e.target.value)}
+                  disabled={isLoadingOutputDevices || outputDevices.length === 0}
+                  className="select-glass flex-1 text-sm"
+                >
+                  {outputDevices.length === 0 ? (
+                    <option value="">No speakers found</option>
+                  ) : (
+                    outputDevices.map((device) => (
+                      <option key={device.deviceId} value={device.deviceId}>
+                        {device.label}
+                        {device.isDefault ? " (Default)" : ""}
+                      </option>
+                    ))
+                  )}
+                </select>
+                <button
+                  onClick={testSound}
+                  disabled={isTesting || !selectedOutputDeviceId}
+                  className="glass-button px-3 py-1.5 text-xs shrink-0"
+                  title="Test selected speaker"
+                >
+                  {isTesting ? (
+                    <span className="flex items-center gap-1">
+                      <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                      </svg>
+                    </span>
+                  ) : (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />
+                    </svg>
+                  )}
+                </button>
+              </div>
             </SettingRow>
           </SettingsSection>
         </div>

--- a/src/hooks/useAudioOutputDevices.ts
+++ b/src/hooks/useAudioOutputDevices.ts
@@ -54,19 +54,23 @@ export function useAudioOutputDevices(): UseAudioOutputDevicesReturn {
 
       setDevices(audioOutputs)
 
-      // Auto-select saved or default device
-      const savedDeviceId = localStorage.getItem('preferredSpeakerDeviceId')
-      if (savedDeviceId && audioOutputs.some(d => d.deviceId === savedDeviceId)) {
-        setSelectedDeviceId(savedDeviceId)
-      } else if (!selectedDeviceId && audioOutputs.length > 0) {
-        setSelectedDeviceId(audioOutputs[0].deviceId)
-      }
+      // Auto-select saved or default device (only if not already selected)
+      setSelectedDeviceId(prev => {
+        if (prev && audioOutputs.some(d => d.deviceId === prev)) {
+          return prev // Keep current selection if valid
+        }
+        const savedDeviceId = localStorage.getItem('preferredSpeakerDeviceId')
+        if (savedDeviceId && audioOutputs.some(d => d.deviceId === savedDeviceId)) {
+          return savedDeviceId
+        }
+        return audioOutputs.length > 0 ? audioOutputs[0].deviceId : null
+      })
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to list devices')
     } finally {
       setIsLoading(false)
     }
-  }, [selectedDeviceId])
+  }, [])
 
   // Select a specific device
   const selectDevice = useCallback((deviceId: string) => {

--- a/src/hooks/useAudioOutputDevices.ts
+++ b/src/hooks/useAudioOutputDevices.ts
@@ -1,0 +1,155 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+
+export interface AudioOutputDevice {
+  deviceId: string
+  label: string
+  isDefault: boolean
+}
+
+export interface UseAudioOutputDevicesReturn {
+  devices: AudioOutputDevice[]
+  selectedDeviceId: string | null
+  isLoading: boolean
+  error: string | null
+  selectDevice: (deviceId: string) => void
+  refreshDevices: () => Promise<void>
+  testSound: () => Promise<void>
+  isTesting: boolean
+}
+
+// Test sound - short click/pop sound
+const TEST_SOUND_URL = 'data:audio/wav;base64,UklGRnoGAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQoGAACBhYqFbF1fdJivrJBhNjVgodDbq2EcBj+a2teleQQAaLvt559NEjOr1PGjYB8JQZ3T7aFbFQxBl8/wqWYfDT+W0NelXhsJOI/L6qJcFQZJk8jlmlkQADqGv9+SSw0BMH+/aqt0Qk5UW0xDbElKW2dgVlxobnZzanl6f398eX19goOEhYeLjY+Qk5eZnJ+hpqmusbS5vcDDxcjLztHU1tnc3+Hi5Obs7/Hz9fb5+/z9/v4='
+
+export function useAudioOutputDevices(): UseAudioOutputDevicesReturn {
+  const [devices, setDevices] = useState<AudioOutputDevice[]>([])
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isTesting, setIsTesting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const audioRef = useRef<HTMLAudioElement | null>(null)
+
+  // Check if setSinkId is supported
+  const isSinkIdSupported = typeof HTMLMediaElement !== 'undefined' &&
+    'setSinkId' in HTMLMediaElement.prototype
+
+  // Fetch available audio output devices
+  const refreshDevices = useCallback(async () => {
+    if (!navigator.mediaDevices?.enumerateDevices) {
+      setError('Device enumeration not supported')
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const allDevices = await navigator.mediaDevices.enumerateDevices()
+      const audioOutputs = allDevices
+        .filter(device => device.kind === 'audiooutput')
+        .map((device, index) => ({
+          deviceId: device.deviceId,
+          label: device.label || `Speaker ${index + 1}`,
+          isDefault: device.deviceId === 'default' || index === 0,
+        }))
+
+      setDevices(audioOutputs)
+
+      // Auto-select saved or default device
+      const savedDeviceId = localStorage.getItem('preferredSpeakerDeviceId')
+      if (savedDeviceId && audioOutputs.some(d => d.deviceId === savedDeviceId)) {
+        setSelectedDeviceId(savedDeviceId)
+      } else if (!selectedDeviceId && audioOutputs.length > 0) {
+        setSelectedDeviceId(audioOutputs[0].deviceId)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to list devices')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [selectedDeviceId])
+
+  // Select a specific device
+  const selectDevice = useCallback((deviceId: string) => {
+    setSelectedDeviceId(deviceId)
+    localStorage.setItem('preferredSpeakerDeviceId', deviceId)
+  }, [])
+
+  // Play test sound through selected device
+  const testSound = useCallback(async () => {
+    if (!selectedDeviceId || isTesting) return
+
+    setIsTesting(true)
+    setError(null)
+
+    try {
+      // Create audio element if not exists
+      if (!audioRef.current) {
+        audioRef.current = new Audio(TEST_SOUND_URL)
+      }
+
+      const audio = audioRef.current
+
+      // Set output device if supported
+      if (isSinkIdSupported && selectedDeviceId !== 'default') {
+        try {
+          await (audio as HTMLAudioElement & { setSinkId: (id: string) => Promise<void> }).setSinkId(selectedDeviceId)
+        } catch (sinkErr) {
+          console.warn('Failed to set sink ID:', sinkErr)
+        }
+      }
+
+      // Play the test sound
+      audio.currentTime = 0
+      await audio.play()
+
+      // Wait for audio to finish
+      await new Promise<void>((resolve) => {
+        audio.onended = () => resolve()
+        // Fallback timeout
+        setTimeout(resolve, 1000)
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to play test sound')
+    } finally {
+      setIsTesting(false)
+    }
+  }, [selectedDeviceId, isTesting, isSinkIdSupported])
+
+  // Load devices on mount
+  useEffect(() => {
+    refreshDevices()
+  }, [refreshDevices])
+
+  // Listen for device changes
+  useEffect(() => {
+    const handleDeviceChange = () => {
+      refreshDevices()
+    }
+
+    navigator.mediaDevices?.addEventListener('devicechange', handleDeviceChange)
+    return () => {
+      navigator.mediaDevices?.removeEventListener('devicechange', handleDeviceChange)
+    }
+  }, [refreshDevices])
+
+  // Cleanup audio element on unmount
+  useEffect(() => {
+    return () => {
+      if (audioRef.current) {
+        audioRef.current.pause()
+        audioRef.current = null
+      }
+    }
+  }, [])
+
+  return {
+    devices,
+    selectedDeviceId,
+    isLoading,
+    error,
+    selectDevice,
+    refreshDevices,
+    testSound,
+    isTesting,
+  }
+}

--- a/src/hooks/useSpeechToText.ts
+++ b/src/hooks/useSpeechToText.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { invoke } from '@tauri-apps/api/core'
+import { useWindowVisibility } from './useWindowVisibility'
 
 // Web Speech API types (not in standard lib)
 interface SpeechRecognitionEvent extends Event {
@@ -75,7 +76,37 @@ function isDevMode(): boolean {
   return window.location.protocol === 'http:'
 }
 
-// Check if microphone permission is granted (non-crashing check)
+// Play silent audio to reset WebKit's audio session and restore system audio
+// This is a workaround for macOS where AVAudioSession doesn't exist
+function resetAudioSession(): void {
+  try {
+    // Create a short silent audio context
+    const audioContext = new (window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext)()
+
+    // Create a silent buffer (100ms)
+    const buffer = audioContext.createBuffer(1, audioContext.sampleRate * 0.1, audioContext.sampleRate)
+    const source = audioContext.createBufferSource()
+    source.buffer = buffer
+    source.connect(audioContext.destination)
+    source.start()
+
+    // Close the context after playing
+    source.onended = () => {
+      audioContext.close().catch(() => {})
+    }
+
+    // Fallback close after 200ms
+    setTimeout(() => {
+      if (audioContext.state !== 'closed') {
+        audioContext.close().catch(() => {})
+      }
+    }, 200)
+  } catch {
+    // Ignore errors - this is just a workaround
+  }
+}
+
+// Check if microphone permission is granted (without triggering audio session)
 async function checkMicrophonePermission(): Promise<boolean> {
   // In dev mode, speech recognition will crash due to missing Info.plist
   // Only the built app has the plist merged
@@ -85,18 +116,17 @@ async function checkMicrophonePermission(): Promise<boolean> {
   }
 
   try {
-    // First check if we can query permissions
+    // Only check via permissions API - don't use getUserMedia as it triggers audio ducking
     if (navigator.permissions) {
       const result = await navigator.permissions.query({ name: 'microphone' as PermissionName })
-      if (result.state === 'denied') return false
+      // If granted or prompt, allow - SpeechRecognition will handle the actual request
+      return result.state !== 'denied'
     }
-    // Try to get microphone access - this won't crash WKWebView
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
-    // Stop all tracks immediately
-    stream.getTracks().forEach(track => track.stop())
+    // If no permissions API, assume we can try
     return true
   } catch {
-    return false
+    // If permissions query fails, let SpeechRecognition try anyway
+    return true
   }
 }
 
@@ -115,23 +145,21 @@ export function useSpeechToText(options: UseSpeechToTextOptions = {}): UseSpeech
   const [error, setError] = useState<string | null>(null)
   const [micPermissionGranted, setMicPermissionGranted] = useState<boolean | null>(null)
 
+  // Track window visibility for lazy/active mode
+  const { isVisible } = useWindowVisibility()
+
   const recognitionRef = useRef<SpeechRecognition | null>(null)
   const isStoppingRef = useRef(false)
   const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastSpeechTimeRef = useRef<number>(0)
   const accumulatedTextRef = useRef('')
 
-  // Check browser support - API must exist AND microphone permission must be granted
+  // Check browser support - API must exist (permission checked lazily on first use)
   const hasAPI = typeof window !== 'undefined' &&
     ('webkitSpeechRecognition' in window || 'SpeechRecognition' in window)
-  const isSupported = hasAPI && micPermissionGranted === true
-
-  // Check microphone permission on mount
-  useEffect(() => {
-    if (hasAPI && micPermissionGranted === null) {
-      checkMicrophonePermission().then(setMicPermissionGranted)
-    }
-  }, [hasAPI, micPermissionGranted])
+  // Show as supported if API exists and permission not yet denied
+  // This prevents audio interruption on app startup
+  const isSupported = hasAPI && micPermissionGranted !== false
 
   // Get speech API language code
   const getSpeechLang = useCallback((appLang: string): string => {
@@ -140,10 +168,14 @@ export function useSpeechToText(options: UseSpeechToTextOptions = {}): UseSpeech
   }, [])
 
   // Clear silence timer
-  const clearSilenceTimer = useCallback(() => {
+  const clearSilenceTimer = useCallback((reactivateSession = false) => {
     if (silenceTimerRef.current) {
       clearTimeout(silenceTimerRef.current)
       silenceTimerRef.current = null
+      // Re-activate audio session only when user speaks again (not when stopping)
+      if (reactivateSession) {
+        invoke('activate_voice_session').catch(() => {})
+      }
     }
     setSilenceDetected(false)
   }, [])
@@ -152,6 +184,11 @@ export function useSpeechToText(options: UseSpeechToTextOptions = {}): UseSpeech
   const startSilenceTimer = useCallback(() => {
     clearSilenceTimer()
     setSilenceDetected(true)
+
+    // Deactivate audio session immediately when silence detected
+    // This restores other apps' audio volume without waiting for timeout
+    invoke('deactivate_voice_session').catch(() => {})
+
     silenceTimerRef.current = setTimeout(() => {
       // Auto-stop after silence timeout
       if (recognitionRef.current && !isStoppingRef.current) {
@@ -183,9 +220,9 @@ export function useSpeechToText(options: UseSpeechToTextOptions = {}): UseSpeech
     }
 
     recognition.onresult = (event: SpeechRecognitionEvent) => {
-      // Reset silence timer on any result
+      // Reset silence timer on any result - reactivate audio session for new speech
       lastSpeechTimeRef.current = Date.now()
-      clearSilenceTimer()
+      clearSilenceTimer(true)
 
       let confirmedText = ''
       let interim = ''
@@ -246,6 +283,8 @@ export function useSpeechToText(options: UseSpeechToTextOptions = {}): UseSpeech
 
       // Deactivate audio session when recognition ends (e.g., silence timeout)
       invoke('deactivate_voice_session').catch(() => {})
+      // Reset WebKit's audio session to restore system audio (macOS workaround)
+      resetAudioSession()
 
       if (!isStoppingRef.current) {
         onEnd?.()
@@ -310,10 +349,11 @@ export function useSpeechToText(options: UseSpeechToTextOptions = {}): UseSpeech
       recognitionRef.current.stop()
     }
     // Deactivate native audio session to restore system audio quality
-    // The notifyOthersOnDeactivation flag tells macOS to restore previous audio routes
     invoke('deactivate_voice_session').catch((e) => {
       console.warn('Failed to deactivate voice session:', e)
     })
+    // Reset WebKit's audio session to restore system audio (macOS workaround)
+    resetAudioSession()
   }, [isListening, clearSilenceTimer])
 
   // Toggle listening
@@ -332,6 +372,22 @@ export function useSpeechToText(options: UseSpeechToTextOptions = {}): UseSpeech
     setInterimTranscript('')
   }, [])
 
+  // Stop listening when window becomes invisible (lazy mode)
+  // This releases audio resources when app is minimized to menu bar
+  useEffect(() => {
+    if (!isVisible && isListening) {
+      // Window hidden - enter lazy mode, release audio
+      clearSilenceTimer()
+      if (recognitionRef.current) {
+        isStoppingRef.current = true
+        recognitionRef.current.abort()
+      }
+      setIsListening(false)
+      invoke('deactivate_voice_session').catch(() => {})
+      resetAudioSession()
+    }
+  }, [isVisible, isListening, clearSilenceTimer])
+
   // Cleanup on unmount
   useEffect(() => {
     return () => {
@@ -341,6 +397,7 @@ export function useSpeechToText(options: UseSpeechToTextOptions = {}): UseSpeech
       }
       // Ensure audio session is deactivated on cleanup
       invoke('deactivate_voice_session').catch(() => {})
+      resetAudioSession()
     }
   }, [clearSilenceTimer])
 

--- a/src/hooks/useWindowVisibility.ts
+++ b/src/hooks/useWindowVisibility.ts
@@ -1,0 +1,96 @@
+import { useState, useEffect, useCallback } from 'react'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { invoke } from '@tauri-apps/api/core'
+
+export interface UseWindowVisibilityReturn {
+  isVisible: boolean
+  isActive: boolean
+}
+
+/**
+ * Hook to track window visibility state (lazy vs active mode)
+ * - Lazy: Window closed/minimized to menu bar - releases audio resources
+ * - Active: Window visible and focused - normal operation
+ */
+export function useWindowVisibility(): UseWindowVisibilityReturn {
+  const [isVisible, setIsVisible] = useState(true)
+  const [isActive, setIsActive] = useState(true)
+
+  // Deactivate audio session when going to lazy mode
+  const enterLazyMode = useCallback(() => {
+    // Release audio session to prevent ducking while in menu bar
+    invoke('deactivate_voice_session').catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    const appWindow = getCurrentWindow()
+    const unlisteners: (() => void)[] = []
+
+    const setup = async () => {
+      // Listen for window close (minimize to menu bar)
+      const unlistenClose = await appWindow.onCloseRequested(() => {
+        setIsVisible(false)
+        setIsActive(false)
+        enterLazyMode()
+      })
+      unlisteners.push(unlistenClose)
+
+      // Listen for focus events
+      const unlistenFocus = await appWindow.onFocusChanged(({ payload: focused }) => {
+        setIsActive(focused)
+        if (!focused) {
+          // Window lost focus - could be going to lazy mode
+          // Don't immediately deactivate, wait for visibility change
+        }
+      })
+      unlisteners.push(unlistenFocus)
+
+      // Listen for window show/hide via Tauri events
+      const { listen } = await import('@tauri-apps/api/event')
+
+      // Window becomes visible (user clicks menu bar icon)
+      const unlistenShow = await listen('tauri://window-created', () => {
+        setIsVisible(true)
+        setIsActive(true)
+      })
+      unlisteners.push(unlistenShow)
+
+      // Also listen to document visibility for browser-level detection
+      const handleVisibilityChange = () => {
+        const visible = document.visibilityState === 'visible'
+        setIsVisible(visible)
+        if (!visible) {
+          enterLazyMode()
+        }
+      }
+      document.addEventListener('visibilitychange', handleVisibilityChange)
+      unlisteners.push(() => document.removeEventListener('visibilitychange', handleVisibilityChange))
+
+      // Window blur/focus at document level
+      const handleWindowBlur = () => {
+        setIsActive(false)
+      }
+      const handleWindowFocus = () => {
+        setIsActive(true)
+        setIsVisible(true)
+      }
+      window.addEventListener('blur', handleWindowBlur)
+      window.addEventListener('focus', handleWindowFocus)
+      unlisteners.push(() => {
+        window.removeEventListener('blur', handleWindowBlur)
+        window.removeEventListener('focus', handleWindowFocus)
+      })
+    }
+
+    setup()
+
+    return () => {
+      unlisteners.forEach(unlisten => unlisten())
+    }
+  }, [enterLazyMode])
+
+  return {
+    isVisible,
+    isActive,
+  }
+}


### PR DESCRIPTION
## Summary
- Add speaker output device selection in Settings with test button
- Implement lazy mic permission check to prevent audio interruption on app open  
- Add window visibility detection for lazy/active audio modes
- Reset WebKit audio session on mic stop to restore system audio
- Release all audio resources when window minimized to menu bar

## Changes
- `useAudioDevices`: lazy permission request only on dropdown focus
- `useAudioOutputDevices`: new hook for speaker selection with test sound
- `useSpeechToText`: improved audio session management, visibility tracking
- `useWindowVisibility`: new hook for lazy/active mode detection
- `SettingsPanel`: added Speaker dropdown with test button in Audio section

## Test Plan
- [ ] Open app while music is playing - should not pause
- [ ] Open Settings - should not pause music
- [ ] Use mic, wait for auto-close - music should restore volume
- [ ] Minimize to menu bar - all audio resources released
- [ ] Test speaker selection with test button