### PR TITLE
feat: add Whisper-based STT for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Offline translation and grammar correction app powered by local AI models. Avail
   - Light: Minor fixes only
   - Medium: Grammar and style improvements
   - Heavy: Full rewrite for clarity
-- **Speech-to-Text** - Voice input with continuous recording and silence detection
+- **Speech-to-Text** - Voice input (macOS: Web Speech API, Linux: Whisper.cpp)
 - **Language Swap** - One-click swap between source and target languages
 - **Offline First** - All processing happens locally via Ollama
 - **Liquid Glass UI** - Modern design with light/dark/system themes
@@ -82,6 +82,36 @@ npm run tauri build
 - **Styling**: Tailwind CSS 4
 - **State**: Zustand 5
 - **AI**: Ollama (local LLMs)
+
+## Linux Speech-to-Text Setup
+
+Linux uses [Whisper.cpp](https://github.com/ggerganov/whisper.cpp) for local speech-to-text (WebKitGTK doesn't support Web Speech API).
+
+### Install Whisper
+
+```bash
+# Option 1: faster-whisper (Python, easiest)
+pip install faster-whisper
+
+# Option 2: whisper.cpp (native, faster)
+git clone https://github.com/ggerganov/whisper.cpp
+cd whisper.cpp && make
+sudo cp main /usr/local/bin/whisper
+```
+
+### Download Model
+
+```bash
+mkdir -p ~/.cache/whisper
+curl -L -o ~/.cache/whisper/ggml-base.bin \
+  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin
+```
+
+### Test STT
+
+```bash
+./scripts/test-linux-stt.sh
+```
 
 ## Configuration
 

--- a/scripts/test-linux-stt.sh
+++ b/scripts/test-linux-stt.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# Test STT functionality on Linux
+# Run this on a real Ubuntu desktop with microphone
+#
+# NOTE: WebKitGTK (used by Tauri on Linux) does NOT support Web Speech API.
+# We use Whisper.cpp as a local fallback for speech-to-text on Linux.
+
+set -e
+
+echo "=== Lingo Leap Linux STT Test ==="
+echo ""
+echo "ℹ  Linux uses Whisper.cpp for local speech-to-text (Web Speech API not supported)"
+echo ""
+
+# Check if running as root
+if [ "$EUID" -eq 0 ]; then
+    echo "⚠ Don't run as root - audio permissions may fail"
+    exit 1
+fi
+
+# Check display
+if [ -z "$DISPLAY" ]; then
+    echo "❌ No display found. Run on a desktop with GUI."
+    exit 1
+fi
+echo "✅ Display: $DISPLAY"
+
+# Check PulseAudio/PipeWire
+if command -v pactl &> /dev/null; then
+    if pactl info &> /dev/null; then
+        echo "✅ Audio server: $(pactl info | grep 'Server Name' | cut -d: -f2)"
+    else
+        echo "❌ Audio server not running"
+        exit 1
+    fi
+else
+    echo "⚠ pactl not found - cannot verify audio server"
+fi
+
+# Check microphone
+echo ""
+echo "=== Checking Microphone ==="
+if command -v arecord &> /dev/null; then
+    MICS=$(arecord -l 2>/dev/null | grep "^card" || echo "")
+    if [ -n "$MICS" ]; then
+        echo "✅ Microphones found:"
+        echo "$MICS"
+    else
+        echo "❌ No microphones found"
+        exit 1
+    fi
+else
+    echo "⚠ arecord not found - install alsa-utils to verify mic"
+fi
+
+# Test microphone recording
+echo ""
+echo "=== Quick Mic Test (3 seconds) ==="
+echo "Speak into your microphone..."
+TEMP_WAV="/tmp/stt-test-$$.wav"
+if command -v arecord &> /dev/null; then
+    timeout 3 arecord -f cd -t wav "$TEMP_WAV" 2>/dev/null || true
+    if [ -f "$TEMP_WAV" ] && [ -s "$TEMP_WAV" ]; then
+        SIZE=$(stat --printf="%s" "$TEMP_WAV" 2>/dev/null || stat -f%z "$TEMP_WAV" 2>/dev/null)
+        echo "✅ Recorded $SIZE bytes"
+        rm -f "$TEMP_WAV"
+    else
+        echo "⚠ Recording may have failed"
+    fi
+fi
+
+# Check if app is installed
+echo ""
+echo "=== Checking App Installation ==="
+if [ -f /usr/bin/tran-app ]; then
+    echo "✅ App installed: /usr/bin/tran-app"
+elif [ -f "./src-tauri/target/release/tran-app" ]; then
+    echo "✅ App built: ./src-tauri/target/release/tran-app"
+    APP_PATH="./src-tauri/target/release/tran-app"
+else
+    echo "❌ App not found. Install with:"
+    echo "   sudo dpkg -i 'Lingo Leap_0.1.0_arm64.deb'"
+    exit 1
+fi
+
+# Check WebKit
+echo ""
+echo "=== Checking WebKit Dependencies ==="
+if ldconfig -p | grep -q libwebkit2gtk-4.1; then
+    echo "✅ WebKit2GTK 4.1 found"
+else
+    echo "❌ WebKit2GTK 4.1 not found. Install:"
+    echo "   sudo apt install libwebkit2gtk-4.1-0"
+    exit 1
+fi
+
+# Check Whisper.cpp
+echo ""
+echo "=== Checking Whisper.cpp (STT Backend) ==="
+WHISPER_FOUND=false
+
+if command -v whisper &> /dev/null; then
+    echo "✅ whisper found: $(which whisper)"
+    WHISPER_FOUND=true
+elif command -v whisper-cpp &> /dev/null; then
+    echo "✅ whisper-cpp found: $(which whisper-cpp)"
+    WHISPER_FOUND=true
+elif command -v faster-whisper &> /dev/null; then
+    echo "✅ faster-whisper found: $(which faster-whisper)"
+    WHISPER_FOUND=true
+fi
+
+if [ "$WHISPER_FOUND" = false ]; then
+    echo "⚠ Whisper not found. STT will not work."
+    echo ""
+    echo "To install whisper.cpp:"
+    echo "   # Option 1: Build from source"
+    echo "   git clone https://github.com/ggerganov/whisper.cpp"
+    echo "   cd whisper.cpp && make && sudo cp main /usr/local/bin/whisper"
+    echo ""
+    echo "   # Option 2: Install faster-whisper (Python)"
+    echo "   pip install faster-whisper"
+    echo ""
+fi
+
+# Check Whisper model
+WHISPER_MODEL="$HOME/.cache/whisper/ggml-base.bin"
+echo ""
+echo "=== Checking Whisper Model ==="
+if [ -f "$WHISPER_MODEL" ]; then
+    echo "✅ Model found: $WHISPER_MODEL"
+else
+    echo "⚠ Model not found. Will be auto-downloaded on first STT use."
+    echo "   Or download manually:"
+    echo "   mkdir -p ~/.cache/whisper"
+    echo "   curl -L -o ~/.cache/whisper/ggml-base.bin \\"
+    echo "     https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin"
+fi
+
+# Launch app
+echo ""
+echo "=== Launching Lingo Leap ==="
+echo "The app will open. Test STT by:"
+echo "  1. Click the microphone button"
+echo "  2. Speak into your mic (recording will start)"
+echo "  3. Click again to stop (audio sent to Whisper)"
+echo "  4. Wait for transcription (shows 'Processing...')"
+echo "  5. Check if text appears in input field"
+echo ""
+if [ "$WHISPER_FOUND" = false ]; then
+    echo "⚠ Note: STT will fail without Whisper installed"
+    echo ""
+fi
+echo "Press Ctrl+C to exit"
+echo ""
+
+if [ -n "$APP_PATH" ]; then
+    "$APP_PATH"
+else
+    /usr/bin/tran-app
+fi

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,5 +35,9 @@ tauri-plugin-global-shortcut = "2"
 tauri-plugin-positioner = { version = "2", features = ["tray-icon"] }
 tauri-plugin-clipboard-manager = "2"
 
+# Linux Whisper STT (WebKitGTK doesn't support Web Speech API)
+[target.'cfg(target_os = "linux")'.dependencies]
+base64 = "0.22"
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(feature, values(\"cargo-clippy\"))"] }

--- a/src-tauri/src/whisper_stt.rs
+++ b/src-tauri/src/whisper_stt.rs
@@ -1,0 +1,181 @@
+//! Whisper-based Speech-to-Text for Linux
+//!
+//! WebKitGTK doesn't support Web Speech API, so we use Whisper as a fallback.
+//! This module handles audio transcription via whisper.cpp CLI.
+
+use std::io::Write;
+use std::process::Command;
+use std::path::PathBuf;
+
+/// Check if Whisper CLI is available on the system
+#[tauri::command]
+pub fn check_whisper_available() -> Result<bool, String> {
+    // Check for whisper.cpp CLI (usually installed as 'whisper' or 'whisper-cpp')
+    let whisper_commands = ["whisper", "whisper-cpp", "main"];
+
+    for cmd in whisper_commands {
+        if Command::new(cmd)
+            .arg("--help")
+            .output()
+            .is_ok()
+        {
+            return Ok(true);
+        }
+    }
+
+    // Check for faster-whisper (Python)
+    if Command::new("faster-whisper")
+        .arg("--help")
+        .output()
+        .is_ok()
+    {
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+/// Get the path to Whisper model (downloads if needed)
+fn get_whisper_model_path() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    PathBuf::from(home).join(".cache/whisper/ggml-base.bin")
+}
+
+/// Transcribe audio data using Whisper
+///
+/// # Arguments
+/// * `audio_data` - Base64 encoded WAV audio data
+/// * `language` - Language code (e.g., "en", "vi", "ja")
+#[tauri::command]
+pub async fn transcribe_audio(audio_data: String, language: String) -> Result<String, String> {
+    // Decode base64 audio data
+    let audio_bytes = base64::Engine::decode(
+        &base64::engine::general_purpose::STANDARD,
+        &audio_data
+    ).map_err(|e| format!("Failed to decode audio: {}", e))?;
+
+    // Create temp file for audio
+    let temp_dir = std::env::temp_dir();
+    let audio_path = temp_dir.join(format!("whisper_input_{}.wav", std::process::id()));
+    let output_path = temp_dir.join(format!("whisper_output_{}", std::process::id()));
+
+    // Write audio to temp file
+    let mut file = std::fs::File::create(&audio_path)
+        .map_err(|e| format!("Failed to create temp file: {}", e))?;
+    file.write_all(&audio_bytes)
+        .map_err(|e| format!("Failed to write audio: {}", e))?;
+    drop(file);
+
+    // Try different Whisper CLI options
+    let result = try_whisper_cli(&audio_path, &output_path, &language).await;
+
+    // Cleanup temp files
+    let _ = std::fs::remove_file(&audio_path);
+    let _ = std::fs::remove_file(output_path.with_extension("txt"));
+
+    result
+}
+
+/// Try to run Whisper CLI with different available commands
+async fn try_whisper_cli(
+    audio_path: &PathBuf,
+    output_path: &PathBuf,
+    language: &str
+) -> Result<String, String> {
+    let model_path = get_whisper_model_path();
+
+    // Try whisper.cpp first (most common on Linux)
+    let whisper_commands = [
+        ("whisper", vec![
+            "-m", model_path.to_str().unwrap_or(""),
+            "-f", audio_path.to_str().unwrap_or(""),
+            "-l", language,
+            "-otxt",
+            "-of", output_path.to_str().unwrap_or(""),
+        ]),
+        ("whisper-cpp", vec![
+            "-m", model_path.to_str().unwrap_or(""),
+            "-f", audio_path.to_str().unwrap_or(""),
+            "-l", language,
+            "-otxt",
+            "-of", output_path.to_str().unwrap_or(""),
+        ]),
+    ];
+
+    for (cmd, args) in whisper_commands {
+        match Command::new(cmd).args(&args).output() {
+            Ok(output) => {
+                if output.status.success() {
+                    // Read the output text file
+                    let txt_path = output_path.with_extension("txt");
+                    if let Ok(text) = std::fs::read_to_string(&txt_path) {
+                        return Ok(text.trim().to_string());
+                    }
+                }
+                // If command exists but failed, log and try next
+                log::warn!("{} failed: {:?}", cmd, String::from_utf8_lossy(&output.stderr));
+            }
+            Err(_) => continue, // Command not found, try next
+        }
+    }
+
+    // Try faster-whisper (Python) as fallback
+    match Command::new("faster-whisper")
+        .args([
+            audio_path.to_str().unwrap_or(""),
+            "--language", language,
+            "--model", "base",
+            "--output_format", "txt",
+        ])
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            return Ok(String::from_utf8_lossy(&output.stdout).trim().to_string());
+        }
+        _ => {}
+    }
+
+    Err("Whisper not available. Install whisper.cpp: https://github.com/ggerganov/whisper.cpp".to_string())
+}
+
+/// Download Whisper model if not present
+#[tauri::command]
+pub async fn ensure_whisper_model() -> Result<String, String> {
+    let model_path = get_whisper_model_path();
+
+    if model_path.exists() {
+        return Ok("Model already downloaded".to_string());
+    }
+
+    // Create cache directory
+    if let Some(parent) = model_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create cache dir: {}", e))?;
+    }
+
+    // Download model using curl or wget
+    let model_url = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin";
+
+    let download_result = Command::new("curl")
+        .args(["-L", "-o", model_path.to_str().unwrap_or(""), model_url])
+        .output();
+
+    match download_result {
+        Ok(output) if output.status.success() => {
+            Ok("Model downloaded successfully".to_string())
+        }
+        _ => {
+            // Try wget as fallback
+            let wget_result = Command::new("wget")
+                .args(["-O", model_path.to_str().unwrap_or(""), model_url])
+                .output();
+
+            match wget_result {
+                Ok(output) if output.status.success() => {
+                    Ok("Model downloaded successfully".to_string())
+                }
+                _ => Err("Failed to download model. Install curl or wget.".to_string())
+            }
+        }
+    }
+}

--- a/src/hooks/useWhisperSTT.ts
+++ b/src/hooks/useWhisperSTT.ts
@@ -1,0 +1,254 @@
+/**
+ * Whisper-based Speech-to-Text for Linux
+ *
+ * WebKitGTK doesn't support Web Speech API, so we use Whisper as a fallback.
+ * This hook records audio via Web Audio API and sends it to the Tauri backend
+ * for transcription using whisper.cpp.
+ */
+
+import { useState, useCallback, useRef } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+
+export interface UseWhisperSTTOptions {
+  lang?: string
+  onTextReady?: (text: string) => void
+  onEnd?: () => void
+  onError?: (error: string) => void
+}
+
+export interface UseWhisperSTTReturn {
+  isListening: boolean
+  isSupported: boolean
+  isProcessing: boolean
+  error: string | null
+  startListening: () => Promise<void>
+  stopListening: () => Promise<void>
+  toggleListening: () => Promise<void>
+}
+
+// Check if Whisper is available (cached result)
+let whisperAvailable: boolean | null = null
+
+async function checkWhisperSupport(): Promise<boolean> {
+  if (whisperAvailable !== null) return whisperAvailable
+
+  try {
+    whisperAvailable = await invoke<boolean>('check_whisper_available')
+  } catch {
+    whisperAvailable = false
+  }
+  return whisperAvailable
+}
+
+// Convert AudioBuffer to WAV format
+function audioBufferToWav(buffer: AudioBuffer): ArrayBuffer {
+  const numChannels = 1 // Mono for speech
+  const sampleRate = 16000 // Whisper prefers 16kHz
+  const bitsPerSample = 16
+
+  // Resample to 16kHz mono
+  const offlineCtx = new OfflineAudioContext(1, buffer.duration * sampleRate, sampleRate)
+  const source = offlineCtx.createBufferSource()
+  source.buffer = buffer
+
+  // Create a new buffer with the target sample rate
+  const length = Math.ceil(buffer.duration * sampleRate)
+  const samples = new Float32Array(length)
+
+  // Simple linear interpolation resampling
+  const ratio = buffer.sampleRate / sampleRate
+  const inputData = buffer.getChannelData(0)
+  for (let i = 0; i < length; i++) {
+    const srcIndex = i * ratio
+    const srcIndexFloor = Math.floor(srcIndex)
+    const srcIndexCeil = Math.min(srcIndexFloor + 1, inputData.length - 1)
+    const t = srcIndex - srcIndexFloor
+    samples[i] = inputData[srcIndexFloor] * (1 - t) + inputData[srcIndexCeil] * t
+  }
+
+  // Convert to 16-bit PCM
+  const dataLength = samples.length * 2
+  const buffer2 = new ArrayBuffer(44 + dataLength)
+  const view = new DataView(buffer2)
+
+  // WAV header
+  const writeString = (offset: number, str: string) => {
+    for (let i = 0; i < str.length; i++) {
+      view.setUint8(offset + i, str.charCodeAt(i))
+    }
+  }
+
+  writeString(0, 'RIFF')
+  view.setUint32(4, 36 + dataLength, true)
+  writeString(8, 'WAVE')
+  writeString(12, 'fmt ')
+  view.setUint32(16, 16, true) // Subchunk1Size
+  view.setUint16(20, 1, true) // AudioFormat (PCM)
+  view.setUint16(22, numChannels, true)
+  view.setUint32(24, sampleRate, true)
+  view.setUint32(28, sampleRate * numChannels * bitsPerSample / 8, true) // ByteRate
+  view.setUint16(32, numChannels * bitsPerSample / 8, true) // BlockAlign
+  view.setUint16(34, bitsPerSample, true)
+  writeString(36, 'data')
+  view.setUint32(40, dataLength, true)
+
+  // Write samples
+  let offset = 44
+  for (let i = 0; i < samples.length; i++) {
+    const s = Math.max(-1, Math.min(1, samples[i]))
+    view.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7FFF, true)
+    offset += 2
+  }
+
+  return buffer2
+}
+
+// Convert ArrayBuffer to base64
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
+export function useWhisperSTT(options: UseWhisperSTTOptions = {}): UseWhisperSTTReturn {
+  const { lang = 'en', onTextReady, onEnd, onError } = options
+
+  const [isListening, setIsListening] = useState(false)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [isSupported, setIsSupported] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null)
+  const audioChunksRef = useRef<Blob[]>([])
+  const streamRef = useRef<MediaStream | null>(null)
+
+  // Check support on first use
+  const ensureSupport = useCallback(async (): Promise<boolean> => {
+    const supported = await checkWhisperSupport()
+    setIsSupported(supported)
+    return supported
+  }, [])
+
+  const startListening = useCallback(async () => {
+    if (isListening || isProcessing) return
+
+    setError(null)
+
+    // Check Whisper support
+    const supported = await ensureSupport()
+    if (!supported) {
+      const msg = 'Whisper not installed. Run: sudo apt install whisper.cpp'
+      setError(msg)
+      onError?.(msg)
+      return
+    }
+
+    try {
+      // Request microphone access
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          sampleRate: 16000,
+          echoCancellation: true,
+          noiseSuppression: true,
+        }
+      })
+
+      streamRef.current = stream
+      audioChunksRef.current = []
+
+      // Create MediaRecorder
+      const mediaRecorder = new MediaRecorder(stream, {
+        mimeType: MediaRecorder.isTypeSupported('audio/webm') ? 'audio/webm' : 'audio/ogg'
+      })
+
+      mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          audioChunksRef.current.push(event.data)
+        }
+      }
+
+      mediaRecorder.onstop = async () => {
+        setIsListening(false)
+        setIsProcessing(true)
+
+        try {
+          // Combine audio chunks
+          const audioBlob = new Blob(audioChunksRef.current, { type: 'audio/webm' })
+
+          // Convert to AudioBuffer
+          const arrayBuffer = await audioBlob.arrayBuffer()
+          const audioContext = new AudioContext({ sampleRate: 16000 })
+          const audioBuffer = await audioContext.decodeAudioData(arrayBuffer)
+          await audioContext.close()
+
+          // Convert to WAV
+          const wavBuffer = audioBufferToWav(audioBuffer)
+          const base64Audio = arrayBufferToBase64(wavBuffer)
+
+          // Send to Whisper backend
+          const transcript = await invoke<string>('transcribe_audio', {
+            audioData: base64Audio,
+            language: lang,
+          })
+
+          if (transcript) {
+            onTextReady?.(transcript)
+          }
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : 'Transcription failed'
+          setError(msg)
+          onError?.(msg)
+        } finally {
+          setIsProcessing(false)
+          onEnd?.()
+        }
+      }
+
+      mediaRecorderRef.current = mediaRecorder
+      mediaRecorder.start(1000) // Collect data every second
+      setIsListening(true)
+
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Failed to access microphone'
+      setError(msg)
+      onError?.(msg)
+    }
+  }, [isListening, isProcessing, lang, ensureSupport, onTextReady, onEnd, onError])
+
+  const stopListening = useCallback(async () => {
+    if (!isListening) return
+
+    // Stop MediaRecorder (triggers onstop which processes audio)
+    if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
+      mediaRecorderRef.current.stop()
+    }
+
+    // Stop all tracks
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach(track => track.stop())
+      streamRef.current = null
+    }
+  }, [isListening])
+
+  const toggleListening = useCallback(async () => {
+    if (isListening) {
+      await stopListening()
+    } else {
+      await startListening()
+    }
+  }, [isListening, startListening, stopListening])
+
+  return {
+    isListening,
+    isSupported,
+    isProcessing,
+    error,
+    startListening,
+    stopListening,
+    toggleListening,
+  }
+}


### PR DESCRIPTION
## Summary
- WebKitGTK doesn't support Web Speech API, so Linux users couldn't use STT
- Added Whisper.cpp as local fallback for speech-to-text on Linux
- Records audio via Web Audio API, sends to Rust backend for transcription

## Changes
- `src-tauri/src/whisper_stt.rs` - Rust backend for Whisper CLI
- `src/hooks/useWhisperSTT.ts` - Audio recording hook  
- `src/hooks/useSpeechToText.ts` - Platform detection & Whisper integration
- `scripts/test-linux-stt.sh` - Test script with install instructions

## Test plan
- [ ] Build app on Linux: `npm run tauri:build`
- [ ] Install Whisper: `pip install faster-whisper` or build whisper.cpp
- [ ] Download model: `curl -L -o ~/.cache/whisper/ggml-base.bin https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin`
- [ ] Run test script: `./scripts/test-linux-stt.sh`
- [ ] Click mic button, speak, click again, verify transcription appears