### PR TITLE
test: add Zustand store tests

### DIFF
--- a/src/stores/appStore.test.ts
+++ b/src/stores/appStore.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useAppStore } from './appStore'
+
+describe('appStore', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      isEnabled: true,
+      mode: 'translate',
+      correctionLevel: 'fix',
+      inputText: '',
+      outputText: '',
+      sourceLang: 'auto',
+      targetLang: 'ja',
+      isLoading: false,
+      error: null,
+      changes: [],
+      isChangesLoading: false,
+    })
+  })
+
+  describe('initial state', () => {
+    it('has correct defaults', () => {
+      const state = useAppStore.getState()
+      expect(state.isEnabled).toBe(true)
+      expect(state.mode).toBe('translate')
+      expect(state.correctionLevel).toBe('fix')
+      expect(state.inputText).toBe('')
+      expect(state.outputText).toBe('')
+      expect(state.sourceLang).toBe('auto')
+      expect(state.targetLang).toBe('ja')
+      expect(state.isLoading).toBe(false)
+      expect(state.error).toBeNull()
+      expect(state.changes).toEqual([])
+      expect(state.isChangesLoading).toBe(false)
+    })
+  })
+
+  describe('setEnabled', () => {
+    it('sets enabled to true', () => {
+      useAppStore.getState().setEnabled(true)
+      expect(useAppStore.getState().isEnabled).toBe(true)
+    })
+
+    it('sets enabled to false', () => {
+      useAppStore.getState().setEnabled(false)
+      expect(useAppStore.getState().isEnabled).toBe(false)
+    })
+  })
+
+  describe('toggleEnabled', () => {
+    it('toggles from true to false', () => {
+      useAppStore.setState({ isEnabled: true })
+      useAppStore.getState().toggleEnabled()
+      expect(useAppStore.getState().isEnabled).toBe(false)
+    })
+
+    it('toggles from false to true', () => {
+      useAppStore.setState({ isEnabled: false })
+      useAppStore.getState().toggleEnabled()
+      expect(useAppStore.getState().isEnabled).toBe(true)
+    })
+  })
+
+  describe('setMode', () => {
+    it('sets mode to translate', () => {
+      useAppStore.getState().setMode('translate')
+      expect(useAppStore.getState().mode).toBe('translate')
+    })
+
+    it('sets mode to correct', () => {
+      useAppStore.getState().setMode('correct')
+      expect(useAppStore.getState().mode).toBe('correct')
+    })
+
+    it('clears output, changes, and error when mode changes', () => {
+      useAppStore.setState({
+        outputText: 'old output',
+        changes: [{ from: 'a', to: 'b', reason: 'test' }],
+        error: 'old error',
+      })
+      useAppStore.getState().setMode('correct')
+      expect(useAppStore.getState().outputText).toBe('')
+      expect(useAppStore.getState().changes).toEqual([])
+      expect(useAppStore.getState().error).toBeNull()
+    })
+  })
+
+  describe('setCorrectionLevel', () => {
+    it('sets level to fix', () => {
+      useAppStore.getState().setCorrectionLevel('fix')
+      expect(useAppStore.getState().correctionLevel).toBe('fix')
+    })
+
+    it('sets level to improve', () => {
+      useAppStore.getState().setCorrectionLevel('improve')
+      expect(useAppStore.getState().correctionLevel).toBe('improve')
+    })
+
+    it('sets level to rewrite', () => {
+      useAppStore.getState().setCorrectionLevel('rewrite')
+      expect(useAppStore.getState().correctionLevel).toBe('rewrite')
+    })
+
+    it('clears output, changes, and error when level changes', () => {
+      useAppStore.setState({
+        outputText: 'old output',
+        changes: [{ from: 'a', to: 'b', reason: 'test' }],
+        error: 'old error',
+      })
+      useAppStore.getState().setCorrectionLevel('improve')
+      expect(useAppStore.getState().outputText).toBe('')
+      expect(useAppStore.getState().changes).toEqual([])
+      expect(useAppStore.getState().error).toBeNull()
+    })
+  })
+
+  describe('setInputText', () => {
+    it('sets input text', () => {
+      useAppStore.getState().setInputText('Hello world')
+      expect(useAppStore.getState().inputText).toBe('Hello world')
+    })
+
+    it('handles empty string', () => {
+      useAppStore.setState({ inputText: 'existing' })
+      useAppStore.getState().setInputText('')
+      expect(useAppStore.getState().inputText).toBe('')
+    })
+  })
+
+  describe('setOutputText', () => {
+    it('sets output text', () => {
+      useAppStore.getState().setOutputText('Translated text')
+      expect(useAppStore.getState().outputText).toBe('Translated text')
+    })
+  })
+
+  describe('setSourceLang', () => {
+    it('sets source language', () => {
+      useAppStore.getState().setSourceLang('en')
+      expect(useAppStore.getState().sourceLang).toBe('en')
+    })
+
+    it('sets to auto', () => {
+      useAppStore.getState().setSourceLang('auto')
+      expect(useAppStore.getState().sourceLang).toBe('auto')
+    })
+  })
+
+  describe('setTargetLang', () => {
+    it('sets target language', () => {
+      useAppStore.getState().setTargetLang('ko')
+      expect(useAppStore.getState().targetLang).toBe('ko')
+    })
+  })
+
+  describe('setLoading', () => {
+    it('sets loading to true', () => {
+      useAppStore.getState().setLoading(true)
+      expect(useAppStore.getState().isLoading).toBe(true)
+    })
+
+    it('sets loading to false', () => {
+      useAppStore.setState({ isLoading: true })
+      useAppStore.getState().setLoading(false)
+      expect(useAppStore.getState().isLoading).toBe(false)
+    })
+  })
+
+  describe('setError', () => {
+    it('sets error message', () => {
+      useAppStore.getState().setError('Something went wrong')
+      expect(useAppStore.getState().error).toBe('Something went wrong')
+    })
+
+    it('clears error with null', () => {
+      useAppStore.setState({ error: 'existing error' })
+      useAppStore.getState().setError(null)
+      expect(useAppStore.getState().error).toBeNull()
+    })
+  })
+
+  describe('setChanges', () => {
+    it('sets changes array', () => {
+      const changes = [
+        { from: 'teh', to: 'the', reason: 'typo' },
+        { from: 'wrold', to: 'world', reason: 'spelling' },
+      ]
+      useAppStore.getState().setChanges(changes)
+      expect(useAppStore.getState().changes).toEqual(changes)
+    })
+
+    it('clears changes with empty array', () => {
+      useAppStore.setState({ changes: [{ from: 'a', to: 'b', reason: 'c' }] })
+      useAppStore.getState().setChanges([])
+      expect(useAppStore.getState().changes).toEqual([])
+    })
+  })
+
+  describe('setChangesLoading', () => {
+    it('sets changes loading to true', () => {
+      useAppStore.getState().setChangesLoading(true)
+      expect(useAppStore.getState().isChangesLoading).toBe(true)
+    })
+
+    it('sets changes loading to false', () => {
+      useAppStore.setState({ isChangesLoading: true })
+      useAppStore.getState().setChangesLoading(false)
+      expect(useAppStore.getState().isChangesLoading).toBe(false)
+    })
+  })
+
+  describe('reset', () => {
+    it('resets all state to initial values', () => {
+      useAppStore.setState({
+        isEnabled: false,
+        mode: 'correct',
+        correctionLevel: 'rewrite',
+        inputText: 'some input',
+        outputText: 'some output',
+        sourceLang: 'en',
+        targetLang: 'ko',
+        isLoading: true,
+        error: 'some error',
+        changes: [{ from: 'a', to: 'b', reason: 'c' }],
+        isChangesLoading: true,
+      })
+
+      useAppStore.getState().reset()
+
+      const state = useAppStore.getState()
+      expect(state.isEnabled).toBe(true)
+      expect(state.mode).toBe('translate')
+      expect(state.correctionLevel).toBe('fix')
+      expect(state.inputText).toBe('')
+      expect(state.outputText).toBe('')
+      expect(state.sourceLang).toBe('auto')
+      expect(state.targetLang).toBe('ja')
+      expect(state.isLoading).toBe(false)
+      expect(state.error).toBeNull()
+      expect(state.changes).toEqual([])
+      expect(state.isChangesLoading).toBe(false)
+    })
+  })
+})

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useSettingsStore } from './settingsStore'
+
+// Mock i18n changeLanguage
+vi.mock('../i18n', () => ({
+  changeLanguage: vi.fn(),
+}))
+
+describe('settingsStore', () => {
+  beforeEach(() => {
+    // Reset store to default values
+    useSettingsStore.setState({
+      ollamaHost: 'http://localhost:11434',
+      translationModel: 'aya:8b',
+      correctionModel: 'qwen2.5:7b',
+      useSameModelForBoth: false,
+      theme: 'system',
+      alwaysOnTop: false,
+      autoHideAfterCopy: false,
+      useStreaming: true,
+      uiLanguage: 'en',
+      defaultTargetLang: 'ja',
+      explanationLang: 'auto',
+      speechLang: 'en',
+      isSetupComplete: false,
+      ollamaInstalled: false,
+      modelsInstalled: false,
+    })
+  })
+
+  describe('initial state', () => {
+    it('has correct defaults', () => {
+      const state = useSettingsStore.getState()
+      expect(state.ollamaHost).toBe('http://localhost:11434')
+      expect(state.translationModel).toBe('aya:8b')
+      expect(state.correctionModel).toBe('qwen2.5:7b')
+      expect(state.useSameModelForBoth).toBe(false)
+      expect(state.theme).toBe('system')
+      expect(state.alwaysOnTop).toBe(false)
+      expect(state.autoHideAfterCopy).toBe(false)
+      expect(state.useStreaming).toBe(true)
+      expect(state.uiLanguage).toBe('en')
+      expect(state.defaultTargetLang).toBe('ja')
+      expect(state.explanationLang).toBe('auto')
+      expect(state.speechLang).toBe('en')
+      expect(state.isSetupComplete).toBe(false)
+      expect(state.ollamaInstalled).toBe(false)
+      expect(state.modelsInstalled).toBe(false)
+    })
+  })
+
+  describe('Ollama settings', () => {
+    it('setOllamaHost updates host', () => {
+      useSettingsStore.getState().setOllamaHost('http://192.168.1.100:11434')
+      expect(useSettingsStore.getState().ollamaHost).toBe('http://192.168.1.100:11434')
+    })
+
+    it('setTranslationModel updates model', () => {
+      useSettingsStore.getState().setTranslationModel('gemma2:9b')
+      expect(useSettingsStore.getState().translationModel).toBe('gemma2:9b')
+    })
+
+    it('setCorrectionModel updates model', () => {
+      useSettingsStore.getState().setCorrectionModel('llama3.2:8b')
+      expect(useSettingsStore.getState().correctionModel).toBe('llama3.2:8b')
+    })
+
+    it('setUseSameModelForBoth updates value', () => {
+      useSettingsStore.getState().setUseSameModelForBoth(true)
+      expect(useSettingsStore.getState().useSameModelForBoth).toBe(true)
+    })
+  })
+
+  describe('UI settings', () => {
+    it('setTheme sets to light', () => {
+      useSettingsStore.getState().setTheme('light')
+      expect(useSettingsStore.getState().theme).toBe('light')
+    })
+
+    it('setTheme sets to dark', () => {
+      useSettingsStore.getState().setTheme('dark')
+      expect(useSettingsStore.getState().theme).toBe('dark')
+    })
+
+    it('setTheme sets to system', () => {
+      useSettingsStore.setState({ theme: 'dark' })
+      useSettingsStore.getState().setTheme('system')
+      expect(useSettingsStore.getState().theme).toBe('system')
+    })
+
+    it('setAlwaysOnTop updates value', () => {
+      useSettingsStore.getState().setAlwaysOnTop(true)
+      expect(useSettingsStore.getState().alwaysOnTop).toBe(true)
+    })
+
+    it('setAutoHideAfterCopy updates value', () => {
+      useSettingsStore.getState().setAutoHideAfterCopy(true)
+      expect(useSettingsStore.getState().autoHideAfterCopy).toBe(true)
+    })
+
+    it('setUseStreaming updates value', () => {
+      useSettingsStore.getState().setUseStreaming(false)
+      expect(useSettingsStore.getState().useStreaming).toBe(false)
+    })
+
+    it('setUILanguage updates language and calls changeLanguage', async () => {
+      const { changeLanguage } = await import('../i18n')
+      useSettingsStore.getState().setUILanguage('ja')
+      expect(useSettingsStore.getState().uiLanguage).toBe('ja')
+      expect(changeLanguage).toHaveBeenCalledWith('ja')
+    })
+
+    it('setUILanguage supports all UI languages', async () => {
+      const { changeLanguage } = await import('../i18n')
+
+      useSettingsStore.getState().setUILanguage('vi')
+      expect(useSettingsStore.getState().uiLanguage).toBe('vi')
+      expect(changeLanguage).toHaveBeenCalledWith('vi')
+
+      useSettingsStore.getState().setUILanguage('ko')
+      expect(useSettingsStore.getState().uiLanguage).toBe('ko')
+      expect(changeLanguage).toHaveBeenCalledWith('ko')
+    })
+  })
+
+  describe('Language preferences', () => {
+    it('setDefaultTargetLang updates language', () => {
+      useSettingsStore.getState().setDefaultTargetLang('ko')
+      expect(useSettingsStore.getState().defaultTargetLang).toBe('ko')
+    })
+
+    it('setExplanationLang updates language', () => {
+      useSettingsStore.getState().setExplanationLang('en')
+      expect(useSettingsStore.getState().explanationLang).toBe('en')
+    })
+
+    it('setExplanationLang sets to auto', () => {
+      useSettingsStore.setState({ explanationLang: 'en' })
+      useSettingsStore.getState().setExplanationLang('auto')
+      expect(useSettingsStore.getState().explanationLang).toBe('auto')
+    })
+
+    it('setSpeechLang updates language', () => {
+      useSettingsStore.getState().setSpeechLang('ja')
+      expect(useSettingsStore.getState().speechLang).toBe('ja')
+    })
+  })
+
+  describe('Setup state', () => {
+    it('setSetupComplete updates value', () => {
+      useSettingsStore.getState().setSetupComplete(true)
+      expect(useSettingsStore.getState().isSetupComplete).toBe(true)
+    })
+
+    it('setOllamaInstalled updates value', () => {
+      useSettingsStore.getState().setOllamaInstalled(true)
+      expect(useSettingsStore.getState().ollamaInstalled).toBe(true)
+    })
+
+    it('setModelsInstalled updates value', () => {
+      useSettingsStore.getState().setModelsInstalled(true)
+      expect(useSettingsStore.getState().modelsInstalled).toBe(true)
+    })
+  })
+
+  describe('persist middleware', () => {
+    it('store has persist name', () => {
+      // The store uses persist middleware with name 'tran-app-settings'
+      // We can verify the store is wrapped with persist by checking its API
+      expect(useSettingsStore.persist).toBeDefined()
+      expect(useSettingsStore.persist.getOptions().name).toBe('tran-app-settings')
+    })
+  })
+})

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -7,6 +7,24 @@ afterEach(() => {
   cleanup()
 })
 
+// Mock localStorage for Zustand persist middleware
+const localStorageMock = {
+  store: {} as Record<string, string>,
+  getItem(key: string) {
+    return this.store[key] ?? null
+  },
+  setItem(key: string, value: string) {
+    this.store[key] = value
+  },
+  removeItem(key: string) {
+    delete this.store[key]
+  },
+  clear() {
+    this.store = {}
+  },
+}
+Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
 // Mock window.matchMedia for theme tests
 Object.defineProperty(window, 'matchMedia', {
   writable: true,


### PR DESCRIPTION
## Summary
- Phase 3 of test coverage plan - Zustand store tests
- 48 tests for appStore and settingsStore
- Added localStorage mock to test-setup.ts for persist middleware

## Test Files
| File | Tests | Coverage |
|------|-------|----------|
| appStore.test.ts | 27 | All state actions |
| settingsStore.test.ts | 21 | Settings + persist |

## Test plan
- [x] All 48 store tests passing
- [x] 100% coverage on stores
- [x] localStorage properly mocked