### PR TITLE
test(hooks): Phase 6 - Complex Hook Tests

### DIFF
--- a/src/hooks/useCorrection.test.ts
+++ b/src/hooks/useCorrection.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useCorrection } from './useCorrection'
+import { useAppStore } from '../stores/appStore'
+import { useSettingsStore } from '../stores/settingsStore'
+import { ollamaClient } from '../lib/ollama-client'
+import { translationCache } from '../lib/cache'
+
+// Mock dependencies
+vi.mock('../lib/ollama-client', () => ({
+  ollamaClient: {
+    setBaseUrl: vi.fn(),
+    generate: vi.fn(),
+    generateStream: vi.fn(),
+  },
+}))
+
+vi.mock('../lib/cache', () => ({
+  translationCache: {
+    get: vi.fn(),
+    set: vi.fn(),
+  },
+  createCorrectionKey: vi.fn((text, lang, level, model) => `${text}-${lang}-${level}-${model}`),
+}))
+
+vi.mock('../lib/language', () => ({
+  detectLanguage: vi.fn(() => 'en'),
+}))
+
+vi.mock('../lib/prompts', () => ({
+  getCorrectionPrompt: vi.fn(() => 'correction prompt'),
+  getChangesExtractionPrompt: vi.fn(() => 'changes prompt'),
+}))
+
+describe('useCorrection', () => {
+  beforeEach(() => {
+    // Reset stores
+    useAppStore.setState({
+      inputText: 'Hello wrold',
+      outputText: '',
+      correctionLevel: 'light',
+      isLoading: false,
+      error: null,
+      changes: [],
+      changesLoading: false,
+    })
+
+    useSettingsStore.setState({
+      correctionModel: 'gemma3:4b',
+      ollamaHost: 'http://localhost:11434',
+      useStreaming: false,
+      explanationLang: 'auto',
+    })
+
+    // Reset mocks with default return values
+    // ollamaClient.generate is used both for main correction AND for extracting changes
+    // Always return a Promise to prevent .then() errors
+    vi.mocked(ollamaClient.generate).mockReset().mockResolvedValue('Hello world')
+    vi.mocked(ollamaClient.generateStream).mockReset()
+    vi.mocked(translationCache.get).mockReset()
+    vi.mocked(translationCache.set).mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns correct, setLevel, and cancel functions', () => {
+    const { result } = renderHook(() => useCorrection())
+
+    expect(typeof result.current.correct).toBe('function')
+    expect(typeof result.current.setLevel).toBe('function')
+    expect(typeof result.current.cancel).toBe('function')
+  })
+
+  it('corrects text with non-streaming mode', async () => {
+    vi.mocked(ollamaClient.generate).mockResolvedValue('Hello world')
+
+    const { result } = renderHook(() => useCorrection())
+
+    await act(async () => {
+      await result.current.correct()
+    })
+
+    expect(useAppStore.getState().outputText).toBe('Hello world')
+    expect(useAppStore.getState().isLoading).toBe(false)
+  })
+
+  it('corrects text with streaming mode', async () => {
+    useSettingsStore.setState({ useStreaming: true })
+
+    async function* mockStream() {
+      yield 'Hello'
+      yield ' world'
+    }
+    vi.mocked(ollamaClient.generateStream).mockReturnValue(mockStream())
+
+    const { result } = renderHook(() => useCorrection())
+
+    await act(async () => {
+      await result.current.correct()
+    })
+
+    expect(useAppStore.getState().outputText).toBe('Hello world')
+  })
+
+  it('uses cached result when available', async () => {
+    vi.mocked(translationCache.get).mockReturnValue('Cached result')
+
+    const { result } = renderHook(() => useCorrection())
+
+    await act(async () => {
+      const res = await result.current.correct()
+      expect(res).toBe('Cached result')
+    })
+
+    // Note: generate IS called for extracting changes (background task),
+    // but not for the main correction
+    expect(useAppStore.getState().outputText).toBe('Cached result')
+    expect(useAppStore.getState().isLoading).toBe(false)
+  })
+
+  it('skips cache when skipCache option is true', async () => {
+    vi.mocked(translationCache.get).mockReturnValue('Cached result')
+    vi.mocked(ollamaClient.generate).mockResolvedValue('Fresh result')
+
+    const { result } = renderHook(() => useCorrection())
+
+    await act(async () => {
+      await result.current.correct(undefined, undefined, { skipCache: true })
+    })
+
+    expect(ollamaClient.generate).toHaveBeenCalled()
+    expect(useAppStore.getState().outputText).toBe('Fresh result')
+  })
+
+  it('does nothing for empty input', async () => {
+    useAppStore.setState({ inputText: '' })
+
+    const { result } = renderHook(() => useCorrection())
+
+    await act(async () => {
+      await result.current.correct()
+    })
+
+    expect(ollamaClient.generate).not.toHaveBeenCalled()
+  })
+
+  it('does nothing for whitespace-only input', async () => {
+    useAppStore.setState({ inputText: '   ' })
+
+    const { result } = renderHook(() => useCorrection())
+
+    await act(async () => {
+      await result.current.correct()
+    })
+
+    expect(ollamaClient.generate).not.toHaveBeenCalled()
+  })
+
+  it('handles error during correction', async () => {
+    vi.mocked(ollamaClient.generate).mockRejectedValue(new Error('Server error'))
+
+    const { result } = renderHook(() => useCorrection())
+
+    await expect(act(async () => {
+      await result.current.correct()
+    })).rejects.toThrow('Server error')
+
+    expect(useAppStore.getState().error).toBe('Server error')
+    expect(useAppStore.getState().isLoading).toBe(false)
+  })
+
+  it('handles non-Error thrown', async () => {
+    vi.mocked(ollamaClient.generate).mockRejectedValue('string error')
+
+    const { result } = renderHook(() => useCorrection())
+
+    await expect(act(async () => {
+      await result.current.correct()
+    })).rejects.toBe('string error')
+
+    expect(useAppStore.getState().error).toBe('Correction failed')
+  })
+
+  it('caches result after correction', async () => {
+    vi.mocked(ollamaClient.generate).mockResolvedValue('Hello world')
+
+    const { result } = renderHook(() => useCorrection())
+
+    await act(async () => {
+      await result.current.correct()
+    })
+
+    expect(translationCache.set).toHaveBeenCalled()
+  })
+
+  it('setLevel updates correction level', () => {
+    const { result } = renderHook(() => useCorrection())
+
+    act(() => {
+      result.current.setLevel('heavy')
+    })
+
+    expect(useAppStore.getState().correctionLevel).toBe('heavy')
+  })
+
+  it('cancel stops ongoing correction', async () => {
+    // Create a correction that won't resolve immediately
+    let resolveGenerate: (value: string) => void
+    vi.mocked(ollamaClient.generate).mockReturnValue(
+      new Promise((resolve) => {
+        resolveGenerate = resolve
+      })
+    )
+
+    const { result } = renderHook(() => useCorrection())
+
+    // Start correction (don't await)
+    act(() => {
+      result.current.correct()
+    })
+
+    await waitFor(() => {
+      expect(useAppStore.getState().isLoading).toBe(true)
+    })
+
+    // Cancel the ongoing correction
+    act(() => {
+      result.current.cancel()
+    })
+
+    expect(useAppStore.getState().isLoading).toBe(false)
+
+    // Clean up - resolve the promise to avoid warning
+    resolveGenerate!('Cancelled')
+  })
+
+  it('corrects with custom text parameter', async () => {
+    vi.mocked(ollamaClient.generate).mockResolvedValue('Custom corrected')
+
+    const { result } = renderHook(() => useCorrection())
+
+    await act(async () => {
+      await result.current.correct('Custom text')
+    })
+
+    expect(useAppStore.getState().outputText).toBe('Custom corrected')
+  })
+
+  it('corrects with custom level parameter', async () => {
+    vi.mocked(ollamaClient.generate).mockResolvedValue('Heavy corrected')
+
+    const { result } = renderHook(() => useCorrection())
+
+    await act(async () => {
+      await result.current.correct(undefined, 'heavy')
+    })
+
+    expect(ollamaClient.generate).toHaveBeenCalled()
+  })
+
+  it('cleans model output artifacts', async () => {
+    vi.mocked(ollamaClient.generate).mockResolvedValue('Hello world<|im_end|>')
+
+    const { result } = renderHook(() => useCorrection())
+
+    await act(async () => {
+      await result.current.correct()
+    })
+
+    expect(useAppStore.getState().outputText).toBe('Hello world')
+  })
+
+  it('sets base URL before request', async () => {
+    vi.mocked(ollamaClient.generate).mockResolvedValue('Hello')
+
+    const { result } = renderHook(() => useCorrection())
+
+    await act(async () => {
+      await result.current.correct()
+    })
+
+    expect(ollamaClient.setBaseUrl).toHaveBeenCalledWith('http://localhost:11434')
+  })
+
+  it('sets loading state during correction', async () => {
+    let resolveGenerate: (value: string) => void
+    vi.mocked(ollamaClient.generate).mockReturnValue(
+      new Promise((resolve) => {
+        resolveGenerate = resolve
+      })
+    )
+
+    const { result } = renderHook(() => useCorrection())
+
+    const correctPromise = act(async () => {
+      result.current.correct()
+    })
+
+    await waitFor(() => {
+      expect(useAppStore.getState().isLoading).toBe(true)
+    })
+
+    await act(async () => {
+      resolveGenerate!('Done')
+    })
+
+    await correctPromise
+  })
+})

--- a/src/hooks/useOllama.test.ts
+++ b/src/hooks/useOllama.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useOllama } from './useOllama'
+import { useSettingsStore } from '../stores/settingsStore'
+import { ollamaClient } from '../lib/ollama-client'
+
+// Mock ollama client
+vi.mock('../lib/ollama-client', () => ({
+  ollamaClient: {
+    setBaseUrl: vi.fn(),
+    checkHealth: vi.fn(),
+    listModels: vi.fn(),
+  },
+}))
+
+describe('useOllama', () => {
+  const mockModels = [
+    { name: 'gemma3:4b', size: 1000000 },
+    { name: 'llama3:8b', size: 2000000 },
+  ]
+
+  beforeEach(() => {
+    // Reset store
+    useSettingsStore.setState({
+      ollamaHost: 'http://localhost:11434',
+      ollamaInstalled: false,
+      modelsInstalled: false,
+      translationModel: 'gemma3:4b',
+      correctionModel: 'gemma3:4b',
+    })
+
+    // Reset mocks
+    vi.mocked(ollamaClient.setBaseUrl).mockClear()
+    vi.mocked(ollamaClient.checkHealth).mockReset()
+    vi.mocked(ollamaClient.listModels).mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns initial checking state', () => {
+    vi.mocked(ollamaClient.checkHealth).mockResolvedValue(true)
+    vi.mocked(ollamaClient.listModels).mockResolvedValue(mockModels)
+
+    const { result } = renderHook(() => useOllama())
+
+    expect(result.current.isChecking).toBe(true)
+    expect(result.current.isConnected).toBe(false)
+  })
+
+  it('connects successfully when Ollama is running', async () => {
+    vi.mocked(ollamaClient.checkHealth).mockResolvedValue(true)
+    vi.mocked(ollamaClient.listModels).mockResolvedValue(mockModels)
+
+    const { result } = renderHook(() => useOllama())
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true)
+    })
+
+    expect(result.current.isChecking).toBe(false)
+    expect(result.current.models).toEqual(mockModels)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('sets ollamaInstalled when connected', async () => {
+    vi.mocked(ollamaClient.checkHealth).mockResolvedValue(true)
+    vi.mocked(ollamaClient.listModels).mockResolvedValue(mockModels)
+
+    renderHook(() => useOllama())
+
+    await waitFor(() => {
+      expect(useSettingsStore.getState().ollamaInstalled).toBe(true)
+    })
+  })
+
+  it('sets modelsInstalled when required models exist', async () => {
+    vi.mocked(ollamaClient.checkHealth).mockResolvedValue(true)
+    vi.mocked(ollamaClient.listModels).mockResolvedValue(mockModels)
+
+    renderHook(() => useOllama())
+
+    await waitFor(() => {
+      expect(useSettingsStore.getState().modelsInstalled).toBe(true)
+    })
+  })
+
+  it('handles connection failure when Ollama not running', async () => {
+    vi.mocked(ollamaClient.checkHealth).mockResolvedValue(false)
+
+    const { result } = renderHook(() => useOllama())
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(false)
+    })
+
+    expect(result.current.error).toBe('Cannot connect to Ollama. Make sure it is running.')
+    expect(useSettingsStore.getState().ollamaInstalled).toBe(false)
+  })
+
+  it('handles network error', async () => {
+    vi.mocked(ollamaClient.checkHealth).mockRejectedValue(new Error('Network error'))
+
+    const { result } = renderHook(() => useOllama())
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('Network error')
+    })
+
+    expect(result.current.isConnected).toBe(false)
+    expect(useSettingsStore.getState().ollamaInstalled).toBe(false)
+  })
+
+  it('handles non-Error thrown', async () => {
+    vi.mocked(ollamaClient.checkHealth).mockRejectedValue('string error')
+
+    const { result } = renderHook(() => useOllama())
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('Failed to connect to Ollama')
+    })
+  })
+
+  it('sets base URL from settings', async () => {
+    useSettingsStore.setState({ ollamaHost: 'http://custom:8080' })
+    vi.mocked(ollamaClient.checkHealth).mockResolvedValue(true)
+    vi.mocked(ollamaClient.listModels).mockResolvedValue([])
+
+    renderHook(() => useOllama())
+
+    await waitFor(() => {
+      expect(ollamaClient.setBaseUrl).toHaveBeenCalledWith('http://custom:8080')
+    })
+  })
+
+  it('hasModel returns true for existing model', async () => {
+    vi.mocked(ollamaClient.checkHealth).mockResolvedValue(true)
+    vi.mocked(ollamaClient.listModels).mockResolvedValue(mockModels)
+
+    const { result } = renderHook(() => useOllama())
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true)
+    })
+
+    expect(result.current.hasModel('gemma3')).toBe(true)
+    expect(result.current.hasModel('gemma3:4b')).toBe(true)
+  })
+
+  it('hasModel returns false for non-existing model', async () => {
+    vi.mocked(ollamaClient.checkHealth).mockResolvedValue(true)
+    vi.mocked(ollamaClient.listModels).mockResolvedValue(mockModels)
+
+    const { result } = renderHook(() => useOllama())
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true)
+    })
+
+    expect(result.current.hasModel('mistral')).toBe(false)
+  })
+
+  it('checkConnection can be called manually', async () => {
+    vi.mocked(ollamaClient.checkHealth).mockResolvedValue(true)
+    vi.mocked(ollamaClient.listModels).mockResolvedValue(mockModels)
+
+    const { result } = renderHook(() => useOllama())
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true)
+    })
+
+    // Clear mocks and call again
+    vi.mocked(ollamaClient.checkHealth).mockClear()
+    vi.mocked(ollamaClient.listModels).mockClear()
+
+    await result.current.checkConnection()
+
+    expect(ollamaClient.checkHealth).toHaveBeenCalled()
+    expect(ollamaClient.listModels).toHaveBeenCalled()
+  })
+
+  it('modelsInstalled is false when required models missing', async () => {
+    useSettingsStore.setState({
+      translationModel: 'mistral:7b',
+      correctionModel: 'mistral:7b',
+    })
+    vi.mocked(ollamaClient.checkHealth).mockResolvedValue(true)
+    vi.mocked(ollamaClient.listModels).mockResolvedValue(mockModels)
+
+    renderHook(() => useOllama())
+
+    await waitFor(() => {
+      expect(useSettingsStore.getState().modelsInstalled).toBe(false)
+    })
+  })
+})

--- a/src/hooks/useSpeechToText.test.ts
+++ b/src/hooks/useSpeechToText.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// Set up location.protocol BEFORE any imports that use it
+// This needs to happen at module load time
+Object.defineProperty(window, 'location', {
+  configurable: true,
+  writable: true,
+  value: { protocol: 'tauri:', hostname: 'localhost' },
+})
+
+// Mock Tauri APIs
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}))
+
+// Mock useWindowVisibility
+vi.mock('./useWindowVisibility', () => ({
+  useWindowVisibility: () => ({ isVisible: true }),
+}))
+
+// Import hook after mocks are set up
+import { useSpeechToText } from './useSpeechToText'
+
+// Global mock recognition instance for test access
+let mockRecognitionInstance: MockSpeechRecognitionClass | null = null
+
+// Mock SpeechRecognition as a class
+class MockSpeechRecognitionClass {
+  continuous = false
+  interimResults = false
+  lang = ''
+  onstart: (() => void) | null = null
+  onresult: ((e: unknown) => void) | null = null
+  onerror: ((e: unknown) => void) | null = null
+  onend: (() => void) | null = null
+
+  start = vi.fn(() => {
+    this.onstart?.()
+  })
+  stop = vi.fn(() => {
+    this.onend?.()
+  })
+  abort = vi.fn()
+
+  constructor() {
+    mockRecognitionInstance = this
+  }
+}
+
+describe('useSpeechToText', () => {
+  // Helper to get the current mock recognition
+  const getMockRecognition = () => mockRecognitionInstance!
+
+  beforeEach(() => {
+    mockRecognitionInstance = null
+
+    // Reset location to tauri protocol (in case test changed it)
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { protocol: 'tauri:', hostname: 'localhost' },
+    })
+
+    // Set up window.webkitSpeechRecognition as a class constructor
+    Object.defineProperty(window, 'webkitSpeechRecognition', {
+      configurable: true,
+      writable: true,
+      value: MockSpeechRecognitionClass,
+    })
+
+    // Mock permissions API
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: {
+        query: vi.fn().mockResolvedValue({ state: 'granted' }),
+      },
+    })
+
+    // Mock AudioContext
+    Object.defineProperty(window, 'AudioContext', {
+      configurable: true,
+      value: vi.fn(() => ({
+        state: 'running',
+        resume: vi.fn().mockResolvedValue(undefined),
+        sampleRate: 44100,
+        createBuffer: vi.fn(() => ({})),
+        createBufferSource: vi.fn(() => ({
+          buffer: null,
+          connect: vi.fn(),
+          start: vi.fn(),
+        })),
+        destination: {},
+      })),
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns isSupported based on API availability', async () => {
+    const { result } = renderHook(() => useSpeechToText())
+    expect(result.current.isSupported).toBe(true)
+  })
+
+  it('returns isSupported true when API available (module level)', () => {
+    // API availability is checked at module load time
+    // Since webkitSpeechRecognition is defined, isSupported should be true
+    const { result } = renderHook(() => useSpeechToText())
+    expect(result.current.isSupported).toBe(true)
+  })
+
+  it('returns initial state', async () => {
+    const { result } = renderHook(() => useSpeechToText())
+
+    expect(result.current.isListening).toBe(false)
+    expect(result.current.transcript).toBe('')
+    expect(result.current.interimTranscript).toBe('')
+    expect(result.current.silenceDetected).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('starts listening', async () => {
+    const { result } = renderHook(() => useSpeechToText())
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    expect(getMockRecognition().start).toHaveBeenCalled()
+    expect(result.current.isListening).toBe(true)
+  })
+
+  it('stops listening', async () => {
+    const { result } = renderHook(() => useSpeechToText())
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    act(() => {
+      result.current.stopListening()
+    })
+
+    expect(getMockRecognition().stop).toHaveBeenCalled()
+  })
+
+  it('toggles listening', async () => {
+    const { result } = renderHook(() => useSpeechToText())
+
+    // Start
+    await act(async () => {
+      await result.current.toggleListening()
+    })
+    expect(result.current.isListening).toBe(true)
+
+    // Stop
+    await act(async () => {
+      await result.current.toggleListening()
+    })
+    expect(getMockRecognition().stop).toHaveBeenCalled()
+  })
+
+  it('clears transcript', async () => {
+    const { result } = renderHook(() => useSpeechToText())
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    act(() => {
+      result.current.clearTranscript()
+    })
+
+    expect(result.current.transcript).toBe('')
+    expect(result.current.interimTranscript).toBe('')
+  })
+
+  it('handles speech recognition error', async () => {
+    const onError = vi.fn()
+    const { result } = renderHook(() => useSpeechToText({ onError }))
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    act(() => {
+      getMockRecognition().onerror?.({ error: 'not-allowed', message: '' })
+    })
+
+    expect(result.current.error).toBe('Microphone access denied')
+    expect(onError).toHaveBeenCalled()
+  })
+
+  it('ignores aborted errors', async () => {
+    const onError = vi.fn()
+    const { result } = renderHook(() => useSpeechToText({ onError }))
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    act(() => {
+      getMockRecognition().onerror?.({ error: 'aborted', message: '' })
+    })
+
+    expect(result.current.error).toBeNull()
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('ignores no-speech errors in continuous mode', async () => {
+    const { result } = renderHook(() => useSpeechToText())
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    act(() => {
+      getMockRecognition().onerror?.({ error: 'no-speech', message: '' })
+    })
+
+    expect(result.current.error).toBeNull()
+  })
+
+  it('calls onTextReady with final text', async () => {
+    const onTextReady = vi.fn()
+    const { result } = renderHook(() => useSpeechToText({ onTextReady }))
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    act(() => {
+      getMockRecognition().onresult?.({
+        resultIndex: 0,
+        results: {
+          length: 1,
+          0: {
+            isFinal: true,
+            length: 1,
+            0: { transcript: 'Hello world' },
+          },
+        },
+      })
+    })
+
+    expect(onTextReady).toHaveBeenCalledWith('Hello world')
+  })
+
+  it('updates interim transcript', async () => {
+    const { result } = renderHook(() => useSpeechToText())
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    act(() => {
+      getMockRecognition().onresult?.({
+        resultIndex: 0,
+        results: {
+          length: 1,
+          0: {
+            isFinal: false,
+            length: 1,
+            0: { transcript: 'Hello wor' },
+          },
+        },
+      })
+    })
+
+    expect(result.current.interimTranscript).toBe('Hello wor')
+  })
+
+  it('calls onEnd when recognition ends', async () => {
+    const onEnd = vi.fn()
+    const { result } = renderHook(() => useSpeechToText({ onEnd }))
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    act(() => {
+      getMockRecognition().onend?.()
+    })
+
+    // onEnd is called when not manually stopping
+    expect(onEnd).toHaveBeenCalled()
+  })
+
+  it('sets correct language code', async () => {
+    const { result } = renderHook(() => useSpeechToText({ lang: 'vi' }))
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    expect(getMockRecognition().lang).toBe('vi-VN')
+  })
+
+  it('defaults to en-US for auto language', async () => {
+    const { result } = renderHook(() => useSpeechToText({ lang: 'auto' }))
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    expect(getMockRecognition().lang).toBe('en-US')
+  })
+
+  it('handles microphone permission denied', async () => {
+    const onError = vi.fn()
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: {
+        query: vi.fn().mockResolvedValue({ state: 'denied' }),
+      },
+    })
+
+    const { result } = renderHook(() => useSpeechToText({ onError }))
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    expect(result.current.error).toBe('Microphone access denied')
+    expect(onError).toHaveBeenCalled()
+  })
+
+  it('does not start when already listening', async () => {
+    const { result } = renderHook(() => useSpeechToText())
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    getMockRecognition().start.mockClear()
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    expect(getMockRecognition().start).not.toHaveBeenCalled()
+  })
+
+  it('handles start error', async () => {
+    // Create a mock class that throws on start
+    class ErrorMockSpeechRecognition {
+      continuous = false
+      interimResults = false
+      lang = ''
+      onstart: (() => void) | null = null
+      onresult: ((e: unknown) => void) | null = null
+      onerror: ((e: unknown) => void) | null = null
+      onend: (() => void) | null = null
+      start = vi.fn(() => { throw new Error('Start failed') })
+      stop = vi.fn()
+      abort = vi.fn()
+    }
+
+    Object.defineProperty(window, 'webkitSpeechRecognition', {
+      configurable: true,
+      writable: true,
+      value: ErrorMockSpeechRecognition,
+    })
+
+    const onError = vi.fn()
+    const { result } = renderHook(() => useSpeechToText({ onError }))
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    expect(result.current.error).toBe('Start failed')
+    expect(onError).toHaveBeenCalled()
+  })
+
+  it('disables in dev mode', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { protocol: 'http:' },
+    })
+
+    const { result } = renderHook(() => useSpeechToText())
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    expect(result.current.error).toBe('Microphone access denied')
+  })
+})

--- a/src/hooks/useTranslation.test.ts
+++ b/src/hooks/useTranslation.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useTranslation } from './useTranslation'
+import { useAppStore } from '../stores/appStore'
+import { useSettingsStore } from '../stores/settingsStore'
+import { translationCache } from '../lib/cache'
+import { TranslationService } from '../services/translation-service'
+
+// Mock dependencies
+vi.mock('../lib/cache', () => ({
+  translationCache: {
+    get: vi.fn(),
+    set: vi.fn(),
+  },
+  createTranslationKey: vi.fn((text, src, tgt, model) => `${text}-${src}-${tgt}-${model}`),
+}))
+
+// Create a mock class for TranslationService
+const mockTranslate = vi.fn()
+const mockTranslateStream = vi.fn()
+const mockDetectSourceLanguage = vi.fn()
+
+vi.mock('../services/translation-service', () => {
+  return {
+    TranslationService: class MockTranslationService {
+      translate = mockTranslate
+      translateStream = mockTranslateStream
+      detectSourceLanguage = mockDetectSourceLanguage
+    },
+  }
+})
+
+describe('useTranslation', () => {
+  beforeEach(() => {
+    // Reset mock functions
+    mockTranslate.mockReset().mockResolvedValue({ translated: 'Xin chào thế giới' })
+    mockTranslateStream.mockReset()
+    mockDetectSourceLanguage.mockReset().mockReturnValue('en')
+
+    // Reset stores
+    useAppStore.setState({
+      inputText: 'Hello world',
+      outputText: '',
+      sourceLang: 'en',
+      targetLang: 'vi',
+      isLoading: false,
+      error: null,
+    })
+
+    useSettingsStore.setState({
+      translationModel: 'gemma3:4b',
+      ollamaHost: 'http://localhost:11434',
+      useStreaming: false,
+    })
+
+    // Reset cache mocks
+    vi.mocked(translationCache.get).mockReset()
+    vi.mocked(translationCache.set).mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns translate, translateText, and cancel functions', () => {
+    const { result } = renderHook(() => useTranslation())
+
+    expect(typeof result.current.translate).toBe('function')
+    expect(typeof result.current.translateText).toBe('function')
+    expect(typeof result.current.cancel).toBe('function')
+  })
+
+  it('translates text with non-streaming mode', async () => {
+    const { result } = renderHook(() => useTranslation())
+
+    await act(async () => {
+      await result.current.translate()
+    })
+
+    expect(useAppStore.getState().outputText).toBe('Xin chào thế giới')
+    expect(useAppStore.getState().isLoading).toBe(false)
+  })
+
+  it('translates text with streaming mode', async () => {
+    useSettingsStore.setState({ useStreaming: true })
+
+    async function* mockStream() {
+      yield 'Xin'
+      yield 'Xin chào'
+      yield 'Xin chào thế giới'
+    }
+    mockTranslateStream.mockReturnValue(mockStream())
+
+    const { result } = renderHook(() => useTranslation())
+
+    await act(async () => {
+      await result.current.translate()
+    })
+
+    expect(useAppStore.getState().outputText).toBe('Xin chào thế giới')
+  })
+
+  it('uses cached result when available', async () => {
+    vi.mocked(translationCache.get).mockReturnValue('Cached translation')
+
+    const { result } = renderHook(() => useTranslation())
+
+    await act(async () => {
+      const res = await result.current.translate()
+      expect(res).toBe('Cached translation')
+    })
+
+    expect(mockTranslate).not.toHaveBeenCalled()
+    expect(useAppStore.getState().outputText).toBe('Cached translation')
+  })
+
+  it('skips cache when skipCache option is true', async () => {
+    vi.mocked(translationCache.get).mockReturnValue('Cached translation')
+
+    const { result } = renderHook(() => useTranslation())
+
+    await act(async () => {
+      await result.current.translate(undefined, { skipCache: true })
+    })
+
+    expect(mockTranslate).toHaveBeenCalled()
+    expect(useAppStore.getState().outputText).toBe('Xin chào thế giới')
+  })
+
+  it('does nothing for empty input', async () => {
+    useAppStore.setState({ inputText: '' })
+
+    const { result } = renderHook(() => useTranslation())
+
+    await act(async () => {
+      await result.current.translate()
+    })
+
+    expect(mockTranslate).not.toHaveBeenCalled()
+  })
+
+  it('does nothing for whitespace-only input', async () => {
+    useAppStore.setState({ inputText: '   ' })
+
+    const { result } = renderHook(() => useTranslation())
+
+    await act(async () => {
+      await result.current.translate()
+    })
+
+    expect(mockTranslate).not.toHaveBeenCalled()
+  })
+
+  it('handles error during translation', async () => {
+    mockTranslate.mockRejectedValue(new Error('Network error'))
+
+    const { result } = renderHook(() => useTranslation())
+
+    await expect(act(async () => {
+      await result.current.translate()
+    })).rejects.toThrow('Network error')
+
+    expect(useAppStore.getState().error).toBe('Network error')
+    expect(useAppStore.getState().isLoading).toBe(false)
+  })
+
+  it('handles non-Error thrown', async () => {
+    mockTranslate.mockRejectedValue('string error')
+
+    const { result } = renderHook(() => useTranslation())
+
+    await expect(act(async () => {
+      await result.current.translate()
+    })).rejects.toBe('string error')
+
+    expect(useAppStore.getState().error).toBe('Translation failed')
+  })
+
+  it('caches result after translation', async () => {
+    const { result } = renderHook(() => useTranslation())
+
+    await act(async () => {
+      await result.current.translate()
+    })
+
+    expect(translationCache.set).toHaveBeenCalled()
+  })
+
+  it('cancel stops ongoing translation', async () => {
+    // Create a translation that won't resolve immediately
+    let resolveTranslate: (value: { translated: string }) => void
+    mockTranslate.mockReturnValue(
+      new Promise((resolve) => {
+        resolveTranslate = resolve
+      })
+    )
+
+    const { result } = renderHook(() => useTranslation())
+
+    // Start translation (don't await)
+    act(() => {
+      result.current.translate()
+    })
+
+    await waitFor(() => {
+      expect(useAppStore.getState().isLoading).toBe(true)
+    })
+
+    // Cancel the ongoing translation
+    act(() => {
+      result.current.cancel()
+    })
+
+    expect(useAppStore.getState().isLoading).toBe(false)
+
+    // Clean up - resolve the promise to avoid warning
+    resolveTranslate!({ translated: 'Cancelled' })
+  })
+
+  it('translates with custom text parameter', async () => {
+    const { result } = renderHook(() => useTranslation())
+
+    await act(async () => {
+      await result.current.translate('Custom text')
+    })
+
+    expect(mockTranslate).toHaveBeenCalled()
+  })
+
+  it('translateText sets input and translates', async () => {
+    const { result } = renderHook(() => useTranslation())
+
+    await act(async () => {
+      await result.current.translateText('New input text')
+    })
+
+    expect(useAppStore.getState().inputText).toBe('New input text')
+    expect(mockTranslate).toHaveBeenCalled()
+  })
+
+  it('auto-detects source language when set to auto', async () => {
+    useAppStore.setState({ sourceLang: 'auto' })
+    mockDetectSourceLanguage.mockReturnValue('fr')
+
+    const { result } = renderHook(() => useTranslation())
+
+    await act(async () => {
+      await result.current.translate()
+    })
+
+    expect(mockDetectSourceLanguage).toHaveBeenCalled()
+    expect(useAppStore.getState().sourceLang).toBe('fr')
+  })
+
+  it('does not detect when source language is specified', async () => {
+    useAppStore.setState({ sourceLang: 'en' })
+
+    const { result } = renderHook(() => useTranslation())
+
+    await act(async () => {
+      await result.current.translate()
+    })
+
+    expect(mockDetectSourceLanguage).not.toHaveBeenCalled()
+  })
+
+  it('sets loading state during translation', async () => {
+    let resolveTranslate: (value: { translated: string }) => void
+    mockTranslate.mockReturnValue(
+      new Promise((resolve) => {
+        resolveTranslate = resolve
+      })
+    )
+
+    const { result } = renderHook(() => useTranslation())
+
+    const translatePromise = act(async () => {
+      result.current.translate()
+    })
+
+    await waitFor(() => {
+      expect(useAppStore.getState().isLoading).toBe(true)
+    })
+
+    await act(async () => {
+      resolveTranslate!({ translated: 'Done' })
+    })
+
+    await translatePromise
+  })
+
+  it('clears output before translating', async () => {
+    useAppStore.setState({ outputText: 'Previous output' })
+
+    let resolveTranslate: (value: { translated: string }) => void
+    mockTranslate.mockReturnValue(
+      new Promise((resolve) => {
+        resolveTranslate = resolve
+      })
+    )
+
+    const { result } = renderHook(() => useTranslation())
+
+    const translatePromise = act(async () => {
+      result.current.translate()
+    })
+
+    await waitFor(() => {
+      expect(useAppStore.getState().outputText).toBe('')
+    })
+
+    await act(async () => {
+      resolveTranslate!({ translated: 'New output' })
+    })
+
+    await translatePromise
+  })
+
+  it('returns translated result', async () => {
+    const { result } = renderHook(() => useTranslation())
+
+    let translatedResult: string | undefined
+    await act(async () => {
+      translatedResult = await result.current.translate()
+    })
+
+    expect(translatedResult).toBe('Xin chào thế giới')
+  })
+})


### PR DESCRIPTION
## Summary
- Add comprehensive tests for complex hooks (Phase 6)
- useOllama: 12 tests for connection management, model listing
- useSpeechToText: 19 tests for speech recognition, permissions
- useCorrection: 17 tests for grammar correction, caching
- useTranslation: 18 tests for translation, streaming, caching

## Test plan
- [x] All 66 new tests pass
- [x] Total test count: 377 passing tests