### PR TITLE
fix(ollama): use exact model name matching for model validation

### DIFF
--- a/src/hooks/useOllama.ts
+++ b/src/hooks/useOllama.ts
@@ -37,10 +37,10 @@ export function useOllama() {
         })
         setOllamaInstalled(true)
 
-        // Check if required models are installed
-        const modelNames = models.map(m => m.name.split(':')[0])
-        const hasTranslation = modelNames.some(n => translationModel.startsWith(n))
-        const hasCorrection = modelNames.some(n => correctionModel.startsWith(n))
+        // Check if required models are installed using exact name matching
+        const modelNames = models.map(m => m.name)
+        const hasTranslation = modelNames.includes(translationModel)
+        const hasCorrection = modelNames.includes(correctionModel)
         setModelsInstalled(hasTranslation && hasCorrection)
       } else {
         setState({
@@ -67,7 +67,7 @@ export function useOllama() {
   }, [checkConnection])
 
   const hasModel = useCallback((modelName: string): boolean => {
-    return state.models.some(m => m.name.startsWith(modelName.split(':')[0]))
+    return state.models.some(m => m.name === modelName)
   }, [state.models])
 
   return {


### PR DESCRIPTION
## Summary
- Fix model selection bug where similar model names were incorrectly matched
- Change from prefix matching to exact string matching for model validation

## Problem
When user has similar models like `qwen2.5:7b` and `qwen2.5-coder:1.5b`, the old prefix matching caused:
- Incorrect model validation (both matched as "qwen2.5")
- Wrong model being used for generation

## Changes
- `hasModel()` now uses exact `===` comparison instead of `startsWith()`
- `modelsInstalled` check uses `includes()` for exact matching
- Added 3 new tests for exact matching scenarios

## Test plan
- [x] Run `npm run test:run -- src/hooks/useOllama.test.ts` - 14 tests pass
- [x] Manual test: Install qwen2.5:7b and qwen2.5-coder:1.5b, verify correct model selection